### PR TITLE
HELM-390: Component to clear Filter Panel data

### DIFF
--- a/src/components/ClearFilterData.tsx
+++ b/src/components/ClearFilterData.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react'
+import { Button } from '@grafana/ui'
+import { clearFilterEditorData } from '../lib/localStorageService'
+
+export const ClearFilterData: React.FC<{}> = () => {
+  const [filterDataCleared, setFilterDataCleared] = useState<boolean>(false)
+
+  const clearFilterData = () => {
+    clearFilterEditorData()
+    setFilterDataCleared(true)
+  }
+
+  return (
+    <>
+      <style>
+        {
+          `
+          .spacer {
+            margin-top: 10px;
+            margin-bottom: 10px;
+          }
+          `
+      }
+      </style>
+      <h3 className='spacer'>Filter Data</h3>
+      <div className='spacer'>
+        OpenNMS Filter Panel data is stored in browser local storage.
+        Click here to remove any existing filter data.
+      </div>
+      <Button
+        onClick={() => clearFilterData()}
+      >
+        Clear Filter Data
+      </Button>
+      {
+        filterDataCleared &&
+        <div className='spacer'>Filter data was cleared.</div>
+      }
+    </>
+  )
+}

--- a/src/datasources/entity-ds/EntityConfigEditor.tsx
+++ b/src/datasources/entity-ds/EntityConfigEditor.tsx
@@ -1,16 +1,20 @@
-import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
-import { DataSourceHttpSettings } from '@grafana/ui';
-import React from 'react';
-import { EntityDataSourceOptions } from './types';
+import React from 'react'
+import { DataSourcePluginOptionsEditorProps } from '@grafana/data'
+import { DataSourceHttpSettings } from '@grafana/ui'
+import { EntityDataSourceOptions } from './types'
+import { ClearFilterData } from '../../components/ClearFilterData'
 
 interface Props extends DataSourcePluginOptionsEditorProps<EntityDataSourceOptions> { }
 
 export const EntityConfigEditor: React.FC<Props> = ({ onOptionsChange, options }) => {
-    return (
-        <DataSourceHttpSettings
-            defaultUrl="https://api.example.com"
-            dataSourceConfig={options}
-            onChange={onOptionsChange}
-        />
-    );
-};
+  return (
+    <>
+      <DataSourceHttpSettings
+          defaultUrl="https://api.example.com"
+          dataSourceConfig={options}
+          onChange={onOptionsChange}
+      />
+      <ClearFilterData />
+    </>
+  )
+}

--- a/src/lib/localStorageService.ts
+++ b/src/lib/localStorageService.ts
@@ -30,3 +30,7 @@ export const loadFilterEditorData = (): FilterEditorData | null => {
 
     return null
 }
+
+export const clearFilterEditorData = () => {
+  localStorage.removeItem(FILTER_PANEL_STORAGE_KEY)
+}

--- a/src/panels/filter-panel/FilterPanelOptions.tsx
+++ b/src/panels/filter-panel/FilterPanelOptions.tsx
@@ -7,6 +7,7 @@ import { FilterPanelDataSource } from './FilterPanelDataSource'
 import { FilterPanelFilterSelector } from './FilterPanelFilterSelector'
 import { FilterPanelActiveFilters } from './FilterPanelActiveFilters'
 import { loadFilterEditorData } from 'lib/localStorageService'
+import { ClearFilterData } from '../../components/ClearFilterData'
 
 interface FilterPanelOptionOptions {
     datasource: SelectableValue<GrafanaDatasource>
@@ -50,6 +51,16 @@ export const FilterPanelOptions: React.FC<PanelOptionsEditorProps<FilterPanelOpt
 
     return (
         <>
+            <style>
+            {
+                `
+                .spacer {
+                    margin-top: 10px;
+                    margin-bottom: 10px;
+                }
+              `
+            }
+            </style>
             <FilterPanelDataSource
                 onChange={(d) => onOptionChange(d, 'datasource')}
                 datasource={internalOptions.datasource}
@@ -64,6 +75,8 @@ export const FilterPanelOptions: React.FC<PanelOptionsEditorProps<FilterPanelOpt
                 activeFilters={internalOptions.activeFilters}
                 onChange={(d) => onOptionChange(d, 'activeFilters')}
             />
+
+            <ClearFilterData />
         </>
     )
 }


### PR DESCRIPTION
Component to clear Filter Panel data in `localStorage`. This is somewhat of a stopgap in case any selected data is present in `localStorage` after a Filter Panel is removed.

Component added to the Entity Datasource configuration screen as well as to the Filter Panel Options configuration.


# External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/HELM-390
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/opennms-helm)
