### PR TITLE
NMS-15544: Update the Ubuntu version used in GitHub Labeler for Grafana Plugin

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,16 +1,16 @@
 # Workflow to associate labels automatically
 name: PR-Labeler
 # Trigger the workflow on pull request events
-on: [pull_request]
+on:
+- pull_request_target
+
 jobs:
   label:
-    runs-on: ubuntu-18.04
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
     steps:
-      # We need to checkout the repository to access the configured file (.github/label-pr.yml)
-      - uses: actions/checkout@v2
-      - name: Labeler
-        uses: docker://decathlon/pull-request-labeler-action:2.0.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Here we can override the path for the action configuration. If none is provided, default one is `.github/label-pr.yml`
-          CONFIG_PATH: ${{ secrets.GITHUB_WORKSPACE }}/.github/label-pr.yml
+      - uses: actions/labeler@v4
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION


# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-15544

