### PR TITLE
HELM-373: Convert Alarm Table Panel

### DIFF
--- a/src/lib/dashboard-convert/alarmTablePanel.ts
+++ b/src/lib/dashboard-convert/alarmTablePanel.ts
@@ -1,0 +1,259 @@
+import { alarmSeverityThemeOptions, fontSizeOptions } from '../../panels/alarm-table/constants'
+import { getAlarmColumns } from '../../datasources/entity-ds/queries'
+import { AlarmTableAlarmDataState, AlarmTablePaginationState } from '../../panels/alarm-table/AlarmTableTypes'
+import { onmsColorArray } from '../../components/OnmsColors'
+
+// map to alarmSeverityThemeOptions
+const legacyAlarmSeverityThemes = [
+    { value: 0, legacyValue: 'default' },
+    { value: 1, legacyValue: 'opennms' },
+    { value: 2, legacyValue: 'omi' },
+    { value: 3, legacyValue: 'nnmi' },
+    { value: 4, legacyValue: 'netcool' },
+    { value: 5, legacyValue: 'custom' }
+]
+
+export const isLegacyAlarmTablePanel = (panel: any) => {
+  return panel && panel.type && panel.type === 'opennms-helm-alarm-table-panel'
+}
+
+const getSeverityThemeValue = (theme: string) => {
+  return legacyAlarmSeverityThemes.find(x => x.legacyValue === (theme || 'default'))?.value || 0
+}
+
+const mapAlarmColumns = (source: any) => {
+  const alarmColumns = getAlarmColumns()
+  const columns: any[] = []
+
+  source.columns?.forEach(col => {
+    const index = alarmColumns.findIndex(c => c.text === col.text)
+
+    if (index >= 0 && index < alarmColumns.length) {
+      const column = alarmColumns[index]
+
+      columns.push({
+        label: column.text,
+        value: index 
+      })
+    }
+  })
+
+  return columns
+}
+
+const createOptions = (source: any) => {
+  const isStyleSeverityColumn = source.severity && source.severity === 'column'
+  const severityThemeValue = getSeverityThemeValue(source.theme)
+
+  const alarmTableAlarms: AlarmTableAlarmDataState = {
+    severityTheme: alarmSeverityThemeOptions.find(x => x.value === severityThemeValue),
+    styleWithSeverity: {
+      label: isStyleSeverityColumn ? 'Column' : 'Off',
+      value: isStyleSeverityColumn ? 1 : 2
+    }
+  }
+
+  const fontSizeLabel = source.fontSize || '100%'
+  const fontSizeValue = fontSizeOptions.find(x => x.label === fontSizeLabel)?.value || 2
+
+  const alarmTablePaging: AlarmTablePaginationState = {
+    rowsPerPage: source.pageSize || 10,
+    pauseRefresh: source.pagingPausesRefresh || false,
+    scroll: source.scroll || false,
+    fontSize: {
+      label: fontSizeLabel,
+      value: fontSizeValue
+    }
+  }
+
+  const options = {
+    alarmTable: {
+      alarmTableAlarms,
+      alarmTableData: {
+        columns: mapAlarmColumns(source)
+      },
+      alarmTablePaging
+    }
+  }
+
+  return options
+}
+
+const createSeverityValueMapping = (source: any) => {
+  // For now, we assume severity value color mappings are based on one of the
+  // predefined themes. May need to update to handle custom themes
+  const severityThemeValue = getSeverityThemeValue(source.theme)
+  const colorArrayIndex = severityThemeValue >= 0 && severityThemeValue <= 4 ? severityThemeValue : 0
+  const colorArray = onmsColorArray[colorArrayIndex]
+
+  const mapping = {
+    options: {
+      INDETERMINATE: {
+        color: colorArray[0],
+        index: 0,
+        text: 'Indeterminate'
+      },
+      CLEARED: {
+        color: colorArray[1],
+        index: 1,
+        text: 'Cleared'
+      },
+      NORMAL: {
+        color: colorArray[2],
+        index: 2,
+        text: 'Normal'
+      },
+      WARNING: {
+        color: colorArray[3],
+        index: 3,
+        text: 'Warning'
+      },
+      MINOR: {
+        color: colorArray[4],
+        index: 4,
+        text: 'Minor'
+      },
+      MAJOR: {
+        color: colorArray[5],
+        index: 5,
+        text: 'Major'
+      },
+      CRITICAL: {
+        color: colorArray[6],
+        index: 6,
+        text: 'Critical'
+      }
+    },
+    type: 'value'
+  }
+
+  return mapping
+}
+
+const createValueMappings = (source: any) => {
+  const mappings: any[] = []
+
+  mappings.push(createSeverityValueMapping(source))
+
+  return mappings
+}
+
+// Does the legacy column data represent an item to be matched by a regex?
+// This is if a column pattern property exists with regex slashes, and
+// the pattern is different than just the column name
+// Otherwise assumed to be a byName match
+const isRegexMatcherOverride = (column: any) => {
+  const pattern: string = column?.style?.pattern || ''
+
+  if (pattern && pattern.startsWith('/') && pattern.endsWith('/')) {
+    const innerPattern = pattern.slice(1, pattern.length - 1)
+
+    return innerPattern !== column.text
+  }
+
+  return false
+}
+
+const createFieldOverrides = (source: any) => {
+  const fieldOverrides: any[] = []
+
+  source.columns?.forEach(col => {
+    const isRegex = isRegexMatcherOverride(col)
+
+    const item = {
+      matcher: {
+        id: isRegex ? 'byRegexp' : 'byName',
+        options: isRegex ? col.style.pattern : col.text
+      },
+      properties: [] as any[]
+    }
+
+    // override column title
+    if (col.text && col.title && (col.text !== col.title)) {
+      item.properties.push({
+        id: 'displayName',
+        value: col.title
+      })
+    }
+
+    // override data type: date
+    // just forcing to dateTimeAsIso for now
+    if (col.style.type === 'date') {
+      item.properties.push({
+        id: 'unit',
+        value: 'dateTimeAsIso'
+      })
+    }
+
+    if (col.style.type === 'number') {
+      item.properties.push({
+        id: 'unit',
+        value: col.unit && col.unit === 'short' ? 'short' : 'number'
+      })
+
+      if (col.style.decimals && col.style.decimals > 0) {
+        item.properties.push({
+          id: 'decimals',
+          value: Number(col.style.decimals)
+        })
+      }
+    }
+
+    if (item.properties.length > 0) {
+      fieldOverrides.push(item)
+    }
+  })
+
+  return fieldOverrides
+}
+
+const createFieldConfig = (source: any) => {
+  const config = {
+    defaults: {
+      color: {
+        mode: 'thresholds'
+      },
+      mappings: createValueMappings(source),
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null
+          },
+          {
+            color: 'red',
+            value: 80
+          }
+        ]
+      }
+    },
+    overrides: createFieldOverrides(source)
+  }
+
+  return config
+}
+
+export const convertLegacyAlarmTablePanel = (source: any) => {
+  const panel = {
+    ...source,
+    fieldConfig: createFieldConfig(source),
+    type: 'opennms-alarm-table-panel',
+    options: createOptions(source),
+    targets: [] // similar or same as entity query editor
+  }
+
+  // remove legacy fields that are not in new data structure
+  delete panel.columns
+  delete panel.fontSize
+  delete panel.styles
+  delete panel.pageSize
+  delete panel.pagingPausesRefresh
+  delete panel.scroll
+  delete panel.severity
+  delete panel.showHeader
+  delete panel.theme
+  delete panel.transform
+
+  return panel
+}

--- a/src/lib/dashboard-convert/convert.ts
+++ b/src/lib/dashboard-convert/convert.ts
@@ -1,7 +1,7 @@
 import { getDataSourceSrv } from '@grafana/runtime'
 import { getDatasourceMetadata } from './datasources'
 import { parseInputs } from './inputs'
-import { parsePanels } from './panels'
+import { convertPanels } from './panels'
 import { parseTemplating } from './templating'
 import { DsType } from './types'
 
@@ -49,8 +49,8 @@ export const dashboardConvert = (sourceJson: string, sourceVersion: string, targ
   dashboard.templating = parsedTemplating
 
   const panels = source.panels || []
-  const parsedPanels = parsePanels(panels, datasourceMap, dsMetas, options.unhideAllQueries)
-  dashboard.panels = parsedPanels
+  const convertedPanels = convertPanels(panels, datasourceMap, dsMetas, options.unhideAllQueries)
+  dashboard.panels = convertedPanels
 
   // remove uid, Grafana will create a new unique one
   delete dashboard.uid

--- a/src/lib/dashboard-convert/entityDs.ts
+++ b/src/lib/dashboard-convert/entityDs.ts
@@ -58,17 +58,17 @@ export const updateEntityQuery = (source: any) => {
       attribute: {
         label: attrName,
         type: {
-          id: "STRING",
-          label: "string"
+          id: 'STRING',
+          label: 'string'
         },
         value: {
           id: attrId,
           label: attrName,  // these aren't necessarily specified in the source
           name: attrName,
           type: {
-            id: "STRING",
-            label: "string"
-          },
+            id: 'STRING',
+            label: 'string'
+          }
         }
       },
       comparator: {

--- a/src/lib/dashboard-convert/filterPanel.ts
+++ b/src/lib/dashboard-convert/filterPanel.ts
@@ -1,28 +1,6 @@
 import { DatasourceMetadata, DsType } from './types'
 
-// Convert any legacy Filter Panels to v9, otherwise just return existing panel object
-export const convertFilterPanels = (panels: any[], datasourceMap: Map<string, DsType>, dsMetas: DatasourceMetadata[]) => {
-  const convertedPanels: any[] = []
-
-  for (const p of panels) {
-    let panel = p
-    
-    if (isLegacyFilterPanel(p)) {
-      panel = convertLegacyFilterPanel(p, datasourceMap, dsMetas)
-    }
-
-    // recursively process panel panels
-    if (p.panels) {
-      panel.panels = convertFilterPanels(p.panels, datasourceMap, dsMetas)
-    }
-
-    convertedPanels.push(panel)
-  }
-
-  return convertedPanels
-}
-
-const isLegacyFilterPanel = (panel: any) => {
+export const isLegacyFilterPanel = (panel: any) => {
   return panel && panel.type && panel.type === 'opennms-helm-filter-panel'
 }
 
@@ -50,7 +28,7 @@ const isLegacyFilterPanel = (panel: any) => {
 //     "value": "multi"
 //   }
 // }
-const convertLegacyFilterPanel = (p: any, datasourceMap: Map<string, DsType>, dsMetas: DatasourceMetadata[]) => {
+export const convertLegacyFilterPanel = (p: any, datasourceMap: Map<string, DsType>, dsMetas: DatasourceMetadata[]) => {
   const panel = { ...p }
 
   const panelDsMeta = dsMetas.find(d => d.datasourceType === 'entity' && d.pluginVersion >= 9)

--- a/src/lib/dashboard-convert/panels.ts
+++ b/src/lib/dashboard-convert/panels.ts
@@ -1,103 +1,108 @@
+import { convertLegacyAlarmTablePanel, isLegacyAlarmTablePanel } from './alarmTablePanel'
 import { getSourceDatasourceInfo } from './datasources'
 import { updateEntityQuery } from './entityDs'
-import { convertFilterPanels } from './filterPanel'
+import { convertLegacyFilterPanel, isLegacyFilterPanel } from './filterPanel'
 import { updateFlowQuery } from './flowDs'
 import { updatePerformanceQuery } from './performanceDs'
 import { DatasourceMetadata, DsType } from './types'
 
-// Parse Dashboard panels
+// Convert Dashboard panels
 // If panel has a legacy datasource, convert the query to use the new schema
-export const parsePanels = (panels: any[], datasourceMap: Map<string, DsType>, dsMetas: DatasourceMetadata[],
+// Then convert any OpenNMS panels
+export const convertPanels = (panels: any[], datasourceMap: Map<string, DsType>, dsMetas: DatasourceMetadata[],
   unhideAllQueries: boolean) => {
-  let convertedPanels: any[] = convertPanelDatasources(panels, datasourceMap, dsMetas, unhideAllQueries)
 
-  convertedPanels = convertFilterPanels(convertedPanels, datasourceMap, dsMetas)
-
-  return convertedPanels
-}
-
-const convertPanelDatasources = (panels: any[], datasourceMap: Map<string, DsType>, dsMetas: DatasourceMetadata[],
-  unhideAllQueries: boolean) => {
   const convertedPanels: any[] = []
 
   for (const p of panels) {
-    const panel = { ...p }
+    let panel = { ...p }
 
-    // p.datasource could be:
-    // - a template variable like '$datasource' which points to an OpenNMS DS
-    //    in which case we leave as-is
-    // - an object like { type, uid }, which points to an OpenNMS DS, in which case we update it to version 9
-    // - either of those which points to a non-OpenNMS DS, in which case leave as-is
-    // - empty/null/undefined, in which case DS should be in the individual targets, leave as-is
-    const panelDsInfo = getSourceDatasourceInfo(panel, datasourceMap)
+    convertPanelDatasources(panel, datasourceMap, dsMetas, unhideAllQueries)
 
-    if (panelDsInfo.isOpenNmsDatasource && !panelDsInfo.isTemplateVariable && panelDsInfo.datasourceType) {
-      const panelDsMeta = dsMetas.find(d => d.datasourceType === panelDsInfo.datasourceType && d.pluginVersion === 9)
-
-      if (panelDsMeta) {
-        panel.datasource = {
-          type: panelDsMeta.type,
-          uid: panelDsMeta.uid
-        }
-      }
-    }
-
-    if (p.targets) {
-      const targets: any[] = []
-
-      for (const t of p.targets) {
-        let updated = { ...t }
-
-        const targetDsInfo = getSourceDatasourceInfo(t, datasourceMap)
-        const isOpenNmsDatasource = panelDsInfo.isOpenNmsDatasource || targetDsInfo.isOpenNmsDatasource
-        const dsType = panelDsInfo.datasourceType || targetDsInfo.datasourceType
-
-        if (isOpenNmsDatasource) {
-          switch (dsType) {
-            case 'entity':
-              updated = updateEntityQuery(t)
-              break
-            case 'performance':
-              updated = updatePerformanceQuery(t)
-              break
-            case 'flow':
-              updated = updateFlowQuery(t)
-              break
-            default:
-              break
-          }
-
-          if (unhideAllQueries) {
-            updated.hide = false
-          }
-
-          if (targetDsInfo.isOpenNmsDatasource && !targetDsInfo.isTemplateVariable && targetDsInfo.datasourceType) {
-            const targetDsMeta = dsMetas.find(d => d.datasourceType === targetDsInfo.datasourceType && d.pluginVersion === 9)
-
-            if (targetDsMeta) {
-              updated.datasource = {
-                type: targetDsMeta.type,
-                uid: targetDsMeta.uid
-              }
-            }
-          }
-        }
-
-        targets.push(updated)
-      }
-
-      // TODO: if p.datasource is a pluginId
-
-      panel.targets = targets
+    if (isLegacyFilterPanel(panel)) {
+      panel = convertLegacyFilterPanel(panel, datasourceMap, dsMetas)
+    } else if (isLegacyAlarmTablePanel(panel)) {
+      panel = convertLegacyAlarmTablePanel(panel)
     }
 
     // recursively process panel panels
-    if (p.panels) {
-      panel.panels = convertPanelDatasources(p.panels, datasourceMap, dsMetas, unhideAllQueries)
+    if (panel.panels) {
+      panel.panels = convertPanels(panel.panels, datasourceMap, dsMetas, unhideAllQueries)
     }
 
     convertedPanels.push(panel)
   }
 
   return convertedPanels
+}
+
+const convertPanelDatasources = (panel: any, datasourceMap: Map<string, DsType>, dsMetas: DatasourceMetadata[],
+  unhideAllQueries: boolean) => {
+
+  // p.datasource could be:
+  // - a template variable like '$datasource' which points to an OpenNMS DS
+  //    in which case we leave as-is
+  // - an object like { type, uid }, which points to an OpenNMS DS, in which case we update it to version 9
+  // - either of those which points to a non-OpenNMS DS, in which case leave as-is
+  // - empty/null/undefined, in which case DS should be in the individual targets, leave as-is
+  const panelDsInfo = getSourceDatasourceInfo(panel, datasourceMap)
+
+  if (panelDsInfo.isOpenNmsDatasource && !panelDsInfo.isTemplateVariable && panelDsInfo.datasourceType) {
+    const panelDsMeta = dsMetas.find(d => d.datasourceType === panelDsInfo.datasourceType && d.pluginVersion === 9)
+
+    if (panelDsMeta) {
+      panel.datasource = {
+        type: panelDsMeta.type,
+        uid: panelDsMeta.uid
+      }
+    }
+  }
+
+  if (panel.targets) {
+    const targets: any[] = []
+
+    for (const t of panel.targets) {
+      let updatedTarget = { ...t }
+
+      const targetDsInfo = getSourceDatasourceInfo(t, datasourceMap)
+      const isOpenNmsDatasource = panelDsInfo.isOpenNmsDatasource || targetDsInfo.isOpenNmsDatasource
+      const dsType = panelDsInfo.datasourceType || targetDsInfo.datasourceType
+
+      if (isOpenNmsDatasource) {
+        switch (dsType) {
+          case 'entity':
+            updatedTarget = updateEntityQuery(t)
+            break
+          case 'performance':
+            updatedTarget = updatePerformanceQuery(t)
+            break
+          case 'flow':
+            updatedTarget = updateFlowQuery(t)
+            break
+          default: break
+        }
+
+        if (unhideAllQueries) {
+          updatedTarget.hide = false
+        }
+
+        if (targetDsInfo.isOpenNmsDatasource && !targetDsInfo.isTemplateVariable && targetDsInfo.datasourceType) {
+          const targetDsMeta = dsMetas.find(d => d.datasourceType === targetDsInfo.datasourceType && d.pluginVersion === 9)
+
+          if (targetDsMeta) {
+            updatedTarget.datasource = {
+              type: targetDsMeta.type,
+              uid: targetDsMeta.uid
+            }
+          }
+        }
+      }
+
+      targets.push(updatedTarget)
+    }
+
+    // TODO: if p.datasource is a pluginId
+
+    panel.targets = targets
+  }
 }

--- a/src/panels/alarm-table/AlarmTableAlarms.tsx
+++ b/src/panels/alarm-table/AlarmTableAlarms.tsx
@@ -3,6 +3,7 @@ import { Select } from '@grafana/ui'
 import { AlarmTableAlarmDataState } from './AlarmTableTypes'
 import { ColorThemeDisplay } from 'components/ColorThemeDisplay'
 import { OnmsInlineField } from 'components/OnmsInlineField'
+import { alarmSeverityThemeOptions } from './constants'
 
 interface AlarmTableAlarmProps {
     onChange: Function
@@ -42,14 +43,7 @@ export const AlarmTableAlarms: React.FC<AlarmTableAlarmProps> = ({ onChange, ala
                 <Select
                     value={alarmTableAlarmData.severityTheme}
                     onChange={(val) => setAlarmTableState('severityTheme', val)}
-                    options={[
-                        { label: 'Default', value: 0 },
-                        { label: 'OpenNMS', value: 1 },
-                        { label: 'Oh My!', value: 2 },
-                        { label: 'No, Never Mind (i)', value: 3 },
-                        { label: 'That\'s Cool', value: 4 },
-                        { label: 'Custom', value: 5 },
-                    ]}
+                    options={alarmSeverityThemeOptions}
                 />
             </OnmsInlineField>
             <ColorThemeDisplay theme={alarmTableAlarmData.severityTheme?.value} />

--- a/src/panels/alarm-table/AlarmTableControl.tsx
+++ b/src/panels/alarm-table/AlarmTableControl.tsx
@@ -19,16 +19,16 @@ export const AlarmTableControl: React.FC<PanelProps<AlarmTableControlProps>> = (
 
     const { state, rowClicked, soloIndex } = useAlarmTableSelection(() => {
         setDetailsModal(true)
-    });
+    })
 
     const { client } = useOpenNMSClient(props.data?.request?.targets?.[0]?.datasource)
-    const { table, menu, menuOpen, setMenuOpen } = useAlarmTableMenu(rowClicked);
-    const { actions, detailsModal, setDetailsModal } = useAlarmTableMenuActions(state.indexes, props?.data?.series[0].fields,() => setMenuOpen(false),client);
-    const { tabActive, tabClick, resetTabs } = useAlarmTableModalTabs();
-    const { alarm, goToAlarm, alarmQuery } = useAlarm(props?.data?.series, soloIndex, client);
-    const { filteredProps, page, setPage, totalPages } = useAlarmProperties(props?.data?.series[0], props?.options?.alarmTable);
+    const { table, menu, menuOpen, setMenuOpen } = useAlarmTableMenu(rowClicked)
+    const { actions, detailsModal, setDetailsModal } = useAlarmTableMenuActions(state.indexes, props?.data?.series?.[0].fields, () => setMenuOpen(false),client)
+    const { tabActive, tabClick, resetTabs } = useAlarmTableModalTabs()
+    const { alarm, goToAlarm, alarmQuery } = useAlarm(props?.data?.series, soloIndex, client)
+    const { filteredProps, page, setPage, totalPages } = useAlarmProperties(props?.data?.series[0], props?.options?.alarmTable)
 
-    useAlarmTableRowHighlighter(state, table);
+    useAlarmTableRowHighlighter(state, table)
     useAlarmTableConfigDefaults(props.fieldConfig, props.onFieldConfigChange, props.options)
 
     const getFontSize = () => {

--- a/src/panels/alarm-table/AlarmTableData.tsx
+++ b/src/panels/alarm-table/AlarmTableData.tsx
@@ -3,6 +3,7 @@ import { Select } from '@grafana/ui'
 import { DragList } from 'components/DragList'
 import { OnmsInlineField } from 'components/OnmsInlineField'
 import { AlarmTableDataState } from './AlarmTableTypes'
+import { alarmTableDefaultColumns } from './constants'
 
 interface AlarmTableDataProps {
     onChange: Function;
@@ -11,15 +12,7 @@ interface AlarmTableDataProps {
 
 export const AlarmTableData: React.FC<AlarmTableDataProps> = ({ onChange, context }) => {
     const [alarmTableData, setAlarmTableData] = useState<AlarmTableDataState>(context?.options?.alarmTable?.alarmTableData || {
-        columns: [
-            { label: 'Is Acknowledged', value: 20 },
-            { label: 'Severity', value: 5 },
-            { label: 'Count', value: 1 },
-            { label: 'Last Event Time', value: 23 },
-            { label: 'Location', value: 8 },
-            { label: 'Node Label', value: 14 },
-            { label: 'Log Message', value: 9 },
-        ]
+        columns: alarmTableDefaultColumns
     })
 
     useEffect(() => {

--- a/src/panels/alarm-table/AlarmTablePaging.tsx
+++ b/src/panels/alarm-table/AlarmTablePaging.tsx
@@ -3,6 +3,7 @@ import { Input, Switch, Select } from '@grafana/ui'
 import { OnmsInlineField } from 'components/OnmsInlineField'
 import { SwitchBox } from 'components/SwitchBox'
 import { AlarmTablePaginationState } from './AlarmTableTypes'
+import { fontSizeOptions } from './constants'
 
 interface AlarmTablePagingPanelProps {
     onChange: Function
@@ -28,22 +29,6 @@ export const AlarmTablePaging: React.FC<AlarmTablePagingPanelProps> = ({ onChang
         onChange(alarmTablePaging)
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [alarmTablePaging])
-
-    const fontSizeOptions = [
-        { label: '80%', value: 0 },
-        { label: '90%', value: 1 },
-        { label: '100%', value: 2 },
-        { label: '110%', value: 3 },
-        { label: '120%', value: 4 },
-        { label: '130%', value: 5 },
-        { label: '140%', value: 6 },
-        { label: '150%', value: 7 },
-        { label: '160%', value: 8 },
-        { label: '180%', value: 9 },
-        { label: '200%', value: 10 },
-        { label: '220%', value: 11 },
-        { label: '250%', value: 12 },
-    ]
 
     return (
         <div>

--- a/src/panels/alarm-table/constants.ts
+++ b/src/panels/alarm-table/constants.ts
@@ -1,0 +1,35 @@
+export const fontSizeOptions = [
+    { label: '80%', value: 0 },
+    { label: '90%', value: 1 },
+    { label: '100%', value: 2 },
+    { label: '110%', value: 3 },
+    { label: '120%', value: 4 },
+    { label: '130%', value: 5 },
+    { label: '140%', value: 6 },
+    { label: '150%', value: 7 },
+    { label: '160%', value: 8 },
+    { label: '180%', value: 9 },
+    { label: '200%', value: 10 },
+    { label: '220%', value: 11 },
+    { label: '250%', value: 12 },
+]
+
+export const alarmSeverityThemeOptions = [
+    { label: 'Default', value: 0 },
+    { label: 'OpenNMS', value: 1 },
+    { label: 'Oh My!', value: 2 },
+    { label: 'No, Never Mind (i)', value: 3 },
+    { label: 'That\'s Cool', value: 4 },
+    { label: 'Custom', value: 5 }
+]
+
+// value matches index in entity-ds/queryAlarms columns
+export const alarmTableDefaultColumns = [
+  { label: 'Is Acknowledged', value: 20 },
+  { label: 'Severity', value: 5 },
+  { label: 'Count', value: 1 },
+  { label: 'Last Event Time', value: 23 },
+  { label: 'Location', value: 8 },
+  { label: 'Node Label', value: 14 },
+  { label: 'Log Message', value: 9 },
+]

--- a/src/panels/alarm-table/hooks/useAlarmProperties.ts
+++ b/src/panels/alarm-table/hooks/useAlarmProperties.ts
@@ -1,17 +1,17 @@
 import { useState, useEffect } from 'react'
 import { ArrayVector } from '@grafana/data'
-import _ from 'lodash'
+import { cloneDeep } from 'lodash'
 
 export const useAlarmProperties = (oldProperties, alarmTable) => {
 
-    const [filteredPropState, setFilteredProps] = useState(_.cloneDeep(oldProperties));
-    const [page, setPage] = useState(1);
-    const [totalPages, setTotalPages] = useState(0);
+    const [filteredPropState, setFilteredProps] = useState(cloneDeep(oldProperties))
+    const [page, setPage] = useState(1)
+    const [totalPages, setTotalPages] = useState(0)
 
     useEffect(() => {
-        const filteredProps = _.cloneDeep(oldProperties);
+        const filteredProps = cloneDeep(oldProperties)
         const totalRows = filteredProps.fields[0].values.length
-        const rowsPerPage = Number(alarmTable.alarmTablePaging.rowsPerPage)
+        const rowsPerPage = Number(alarmTable.alarmTablePaging?.rowsPerPage || 10)
 
         if (filteredProps && filteredProps.meta?.entity_metadata && filteredProps.name && filteredProps.name === 'alarms') {
             // Allow background color for severity column.
@@ -20,17 +20,19 @@ export const useAlarmProperties = (oldProperties, alarmTable) => {
                     if (field.name === 'Severity') {
                         field.config.custom = { displayMode: 'color-background' }
                     }
-                    return field;
+                    return field
                 })
             } 
 
             // Filter our columns according to our configured approved fields.
             filteredProps.fields = filteredProps.fields.filter((fil) => {
-                let shouldIncludeThisField = true;
+                let shouldIncludeThisField = true
+
                 if (alarmTable?.alarmTableData) {
                     shouldIncludeThisField = !!alarmTable?.alarmTableData.columns?.find((col) => col.label === fil.name)
                 }
-                return shouldIncludeThisField;
+
+                return shouldIncludeThisField
             })
 
             //Sort our columns based on the user provided order
@@ -41,24 +43,27 @@ export const useAlarmProperties = (oldProperties, alarmTable) => {
             })
 
             if (rowsPerPage > 0 && totalRows > rowsPerPage) {
-                const myPage = page;
+                const myPage = page
+
                 filteredProps.fields = filteredProps.fields.map((field) => {
-                    const oldValues = [...field.values.buffer];
-                    const start = (myPage - 1) * rowsPerPage;
-                    const end = start + rowsPerPage;
+                    const oldValues = [...field.values.buffer]
+                    const start = (myPage - 1) * rowsPerPage
+                    const end = start + rowsPerPage
                     const spliced = oldValues.splice(start, end)
                     field.values = new ArrayVector(spliced) 
-                    return field;
+                    return field
                 })
+
                 filteredProps.length = filteredProps.fields[0]?.values.length || 0
             } else {
-                filteredProps.length = totalRows;
+                filteredProps.length = totalRows
             }
+
             setFilteredProps(filteredProps)
             setTotalPages(Math.ceil(totalRows / rowsPerPage))
         }
 
-    }, [alarmTable?.alarmTableData, page, alarmTable.alarmTablePaging.rowsPerPage, oldProperties,alarmTable?.alarmTableAlarms?.styleWithSeverity])
+    }, [alarmTable?.alarmTableData, page, alarmTable.alarmTablePaging?.rowsPerPage, oldProperties,alarmTable?.alarmTableAlarms?.styleWithSeverity])
 
     useEffect(() => {
         const scrollView = document.querySelector('.scroll .scrollbar-view')


### PR DESCRIPTION
Update the Dashboard Conversion tool to convert the Alarm Table Panel.

Also refactors the conversion code to process all panels in a single run.

Not every possible legacy Alarm Table option has been converted, and some do not apply any more since we are relying more on built-in Grafana options, but most significant things have been converted. It is expected that a few more items will need to be done.


# External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/HELM-373
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/opennms-helm)
