### PR TITLE
HELM-391: Conversion tool for Alarm Histogram

### DIFF
--- a/src/lib/dashboard-convert/alarmHistogramPanel.ts
+++ b/src/lib/dashboard-convert/alarmHistogramPanel.ts
@@ -1,0 +1,53 @@
+import { AlarmDirections, AlarmGroups } from '../../panels/alarm-histogram/constants'
+
+export const isLegacyAlarmHistogramPanel = (panel: any) => {
+  return panel && panel.type && panel.type === 'opennms-helm-alarm-histogram-panel'
+}
+
+export const convertLegacyAlarmHistogramPanel = (source: any) => {
+  const panel = {
+    ...source,
+    type: 'opennms-alarm-histogram-panel',
+    options: createOptions(source)
+  }
+
+  // remove legacy fields that are not in new data structure
+  // targets should already have been converted
+  delete panel.direction
+  delete panel.groupProperty
+
+  return panel
+}
+
+const getAlarmDirection = (source: any) => {
+  const legacyDirection: string = source.direction || 'horizontal'
+
+  if (legacyDirection === 'horizontal') {
+    return AlarmDirections.Horizontal.value
+  } else if (legacyDirection === 'vertical') {
+    return AlarmDirections.Vertical.value
+  }
+
+  return AlarmDirections.Horizontal.value
+}
+
+const getAlarmGroup = (source: any) => {
+  const legacyGroup: string = source.groupProperty || 'acknowledged'
+
+  if (legacyGroup === 'acknowledged') {
+    return AlarmGroups.Acknowledged.value
+  } else if (legacyGroup === 'severity') {
+    return AlarmGroups.Severity.value
+  }
+
+  return AlarmDirections.Horizontal.value
+}
+
+const createOptions = (source: any) => {
+  const options = {
+    alarmDirection: getAlarmDirection(source),
+    alarmGroup: getAlarmGroup(source)
+  }
+
+  return options
+}

--- a/src/lib/dashboard-convert/alarmTablePanel.ts
+++ b/src/lib/dashboard-convert/alarmTablePanel.ts
@@ -1,7 +1,7 @@
-import { alarmSeverityThemeOptions, fontSizeOptions } from '../../panels/alarm-table/constants'
+import { onmsColorArray } from '../../components/OnmsColors'
 import { getAlarmColumns } from '../../datasources/entity-ds/queries'
 import { AlarmTableAlarmDataState, AlarmTablePaginationState } from '../../panels/alarm-table/AlarmTableTypes'
-import { onmsColorArray } from '../../components/OnmsColors'
+import { alarmSeverityThemeOptions, fontSizeOptions } from '../../panels/alarm-table/constants'
 
 // map to alarmSeverityThemeOptions
 const legacyAlarmSeverityThemes = [
@@ -239,11 +239,11 @@ export const convertLegacyAlarmTablePanel = (source: any) => {
     ...source,
     fieldConfig: createFieldConfig(source),
     type: 'opennms-alarm-table-panel',
-    options: createOptions(source),
-    targets: [] // similar or same as entity query editor
+    options: createOptions(source)
   }
 
   // remove legacy fields that are not in new data structure
+  // targets should already have been converted
   delete panel.columns
   delete panel.fontSize
   delete panel.styles

--- a/src/lib/dashboard-convert/panels.ts
+++ b/src/lib/dashboard-convert/panels.ts
@@ -1,4 +1,5 @@
 import { convertLegacyAlarmTablePanel, isLegacyAlarmTablePanel } from './alarmTablePanel'
+import { convertLegacyAlarmHistogramPanel, isLegacyAlarmHistogramPanel } from './alarmHistogramPanel'
 import { getSourceDatasourceInfo } from './datasources'
 import { updateEntityQuery } from './entityDs'
 import { convertLegacyFilterPanel, isLegacyFilterPanel } from './filterPanel'
@@ -23,6 +24,8 @@ export const convertPanels = (panels: any[], datasourceMap: Map<string, DsType>,
       panel = convertLegacyFilterPanel(panel, datasourceMap, dsMetas)
     } else if (isLegacyAlarmTablePanel(panel)) {
       panel = convertLegacyAlarmTablePanel(panel)
+    } else if (isLegacyAlarmHistogramPanel(panel)) {
+      panel = convertLegacyAlarmHistogramPanel(panel)
     }
 
     // recursively process panel panels

--- a/src/panels/alarm-histogram/constants.ts
+++ b/src/panels/alarm-histogram/constants.ts
@@ -1,13 +1,13 @@
 export const defaultColors = ['rgba(245, 54, 54, 0.9)', 'rgba(237, 129, 40, 0.89)', 'rgba(50, 172, 45, 0.97)']
 
 export const AlarmDirections = {
-    Vertical: {label:'Vertical',value:1},
-    Horizontal: {label: 'Horizontal', value:2}
+    Vertical: { label: 'Vertical', value: 1 },
+    Horizontal: { label: 'Horizontal', value: 2 }
 }
 
 export const AlarmGroups = {
-    Acknowledged: {label: 'Acknowledged', value:1},
-    Severity: {label: 'Severity', value:2},
+    Acknowledged: { label: 'Acknowledged', value: 1 },
+    Severity: { label: 'Severity', value: 2 },
 }
 
 export const AcknowledgedAlarms = {


### PR DESCRIPTION
Update the Dashboard Conversion tool to convert the Alarm Histogram.

Also fixed this and Alarm Table converter to not override `targets` which are converted in a previous step.


# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/${JIRA-ISSUE-NUMBER}
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/opennms-helm)
