### PR TITLE
Added support for scopedVars in StringProps query

### DIFF
--- a/src/datasources/perf-ds/PerformanceDataSource.tsx
+++ b/src/datasources/perf-ds/PerformanceDataSource.tsx
@@ -82,6 +82,9 @@ export class PerformanceDataSource extends DataSourceApi<PerformanceQuery> {
 
         let sources = interpolate(source, attributes, interpolationVars, callback)
 
+        // There is no need for include scopedVars here, because additional resources and attributes are defined
+        // using glob expressions, so they will never come from template variables.
+        // If they come from template variables they should be already handled in the previous interpolate call.
         const additionalSources = await this.getAdditionalSources(sources)
 
         if (additionalSources.length > 0) {
@@ -387,6 +390,11 @@ export class PerformanceDataSource extends DataSourceApi<PerformanceQuery> {
         return resourcesWithAttributes
     }
 
+    /**
+     * Used when defining template variables, hence there is no scopedVars argument in templateSrv.replace() method
+     * @param args 
+     * @returns 
+     */
     replaceTemplateVariablesInArguments = (args?: string[]) => {
         if (args && Array.isArray(args)) {
             args = args.map(arg => trimChar(this.templateSrv.replace(arg), '{', '}'))

--- a/src/datasources/perf-ds/queries/queryStringProperties.ts
+++ b/src/datasources/perf-ds/queries/queryStringProperties.ts
@@ -44,8 +44,8 @@ const isDefinedStringPropertyQuery = (q: PerformanceQuery | undefined) => {
     return ps && (ps.node.id || ps.node.label) && (ps.resource.id || ps.resource.label) && ps.stringProperty.value ? true : false
 }
 
-export const getDefinedStringPropertyQueries = (templateSrv: TemplateSrv, targets: PerformanceQuery[]) => {
-    const definedQueries: DefinedStringPropertyQuery[] = targets
+export const getDefinedStringPropertyQueries = (templateSrv: TemplateSrv, request: DataQueryRequest<PerformanceQuery>) => {
+    const definedQueries: DefinedStringPropertyQuery[] = request.targets
         .filter(q => !q.hide)
         .filter(isDefinedStringPropertyQuery)
         .map(q => {
@@ -61,8 +61,8 @@ export const getDefinedStringPropertyQueries = (templateSrv: TemplateSrv, target
                 datasource: q.datasource,
 
                 // StringPropertyQuery fields
-                nodeId: trimChar(templateSrv.replace('' + nodeId), '{', '}'),
-                resourceId: trimChar(templateSrv.replace(getResourceId(resourceId)), '{', '}'),
+                nodeId: trimChar(templateSrv.replace(nodeId, request.scopedVars), '{', '}'),
+                resourceId: trimChar(templateSrv.replace(getResourceId(resourceId), request.scopedVars), '{', '}'),
                 stringProperty: q.stringPropertyState.stringProperty.value
             } as DefinedStringPropertyQuery
         })
@@ -212,7 +212,7 @@ export const queryStringProperties = async (
     templateSrv: TemplateSrv,
     request: DataQueryRequest<PerformanceQuery>): Promise<DataQueryResponse> => {
 
-    const definedQueries = getDefinedStringPropertyQueries(templateSrv, request.targets)
+    const definedQueries = getDefinedStringPropertyQueries(templateSrv, request)
 
     const client: Client = await clientDelegate.getClientWithMetadata()
     const metadata: ServerMetadata = client.http.server.metadata;


### PR DESCRIPTION
Added support for scopedVars in StringProps query

# Pull Request Check Sheet

* [ ] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [ ] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [ ] Have you made a comment in that issue which points back to this PR?
* [ ] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [ ] If this is a new feature, is there documentation?
* [ ] If this is a new feature or substantial change, are there tests that cover it?

# Pull Request Process

One or more reviewers should be assigned to each PR.

If you know that a particular person is subject matter expert in the area your PR affects, feel free to assign one or more reviewers when you create this PR, otherwise reviewers will be assigned for you.

Once the reviewer(s) accept the PR and the branch passes continuous integration in Bamboo, the PR is eligible for merge.

At that time, if you have commit access (are an OpenNMS Group employee or a member of the Order of the Green Polo) you are welcome to merge the PR.
Otherwise, a reviewer can merge it for you.

Thanks for taking time to contribute!

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/HELM-342
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/opennms-helm)
