### PR TITLE
Fix Performance DS Filter Query, add StringProperty conversion

### DIFF
--- a/src/datasources/perf-ds/PerformanceFilter.tsx
+++ b/src/datasources/perf-ds/PerformanceFilter.tsx
@@ -25,8 +25,8 @@ export interface PerformanceFilterProps {
 
 export const PerformanceFilter: React.FC<PerformanceFilterProps> = ({ query, updateQuery, loadFilters }) => {
     // TODO: Initialize these from 'query' prop
-    const [filter, setFilter] = useState<SelectableValue<FilterResponse>>({});
-    const [filterState, setFilterState] = useState<Record<string, {value: any, filter: any}>>({});
+    const [filter, setFilter] = useState<SelectableValue<FilterResponse>>(query.filter);
+    const [filterState, setFilterState] = useState<Record<string, {value: any, filter: any}>>(query.filterState);
 
     const updateFilterState = (propertyName: string, value: {value: any, filter: any}) => {
         setFilterState({ ...filterState, [propertyName]: value })
@@ -34,6 +34,7 @@ export const PerformanceFilter: React.FC<PerformanceFilterProps> = ({ query, upd
 
     useEffect(() => {
         updateQuery(filter, filterState);
+
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [filterState, filter])
 
@@ -58,9 +59,9 @@ export const PerformanceFilter: React.FC<PerformanceFilterProps> = ({ query, upd
                             {param.type === 'boolean' &&
                                 <Segment
                                     placeholder={param.key}
-                                    value={filterState[param.displayName]?.value || false}
+                                    value={filterState[param.key]?.value || false}
                                     onChange={(value: unknown) => {
-                                        updateFilterState(param.displayName, {value,filter:param})
+                                        updateFilterState(param.key, { value, filter: param })
                                     }}
                                     options={[{ label: 'True', value: 'true'}, { label: 'False', value: 'false' }]}
                                 />
@@ -68,26 +69,23 @@ export const PerformanceFilter: React.FC<PerformanceFilterProps> = ({ query, upd
                             {(param.type === 'double' || param.type === 'int' || param.type === 'long') &&
                                 <SegmentInput
                                     type='number'
-                                    value={filterState[param.displayName]?.value || ''}
+                                    value={filterState[param.key]?.value || ''}
                                     placeholder={param.key}
                                     onChange={(value) => {
-                                        updateFilterState(param.displayName, {value,filter:param})
+                                        updateFilterState(param.key, { value, filter: param })
                                     }}
                                 />
                             }
-
-                            {
-                                param.type !== 'double' && param.type !== 'boolean' && param.type !== 'int' && param.type !== 'long' &&
-
+                            {(param.type !== 'double' && param.type !== 'boolean' && param.type !== 'int' && param.type !== 'long') &&
                                 <SegmentInput
-                                    value={filterState[param.displayName]?.value || ''}
+                                    value={filterState[param.key]?.value || ''}
                                     placeholder={param.key}
                                     onChange={(value) => {
-                                        updateFilterState(param.displayName, {value,filter:param})
+                                        updateFilterState(param.key, { value, filter: param })
                                     }}
                                 />}
                             <p style={{ margin: 0, paddingTop: 6, paddingLeft: 5 }}>
-                                {param.description}
+                                { param.description }
                             </p>
                         </SegmentSectionWithIcon>
                     </>

--- a/src/datasources/perf-ds/PerformanceFilter.tsx
+++ b/src/datasources/perf-ds/PerformanceFilter.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react'
-import { SelectableValue } from '@grafana/data';
-import { Segment, SegmentAsync, SegmentInput } from '@grafana/ui';
-import { SegmentSectionWithIcon } from 'components/SegmentSectionWithIcon';
+import { SelectableValue } from '@grafana/data'
+import { Segment, SegmentAsync, SegmentInput } from '@grafana/ui'
+import { SegmentSectionWithIcon } from 'components/SegmentSectionWithIcon'
 import { PerformanceQuery } from './types'
 
 export interface FilterItem {
@@ -24,7 +24,6 @@ export interface PerformanceFilterProps {
 }
 
 export const PerformanceFilter: React.FC<PerformanceFilterProps> = ({ query, updateQuery, loadFilters }) => {
-    // TODO: Initialize these from 'query' prop
     const [filter, setFilter] = useState<SelectableValue<FilterResponse>>(query.filter);
     const [filterState, setFilterState] = useState<Record<string, {value: any, filter: any}>>(query.filterState);
 


### PR DESCRIPTION
Various Performance datasource fixes:

- in Performance Filter query editor, initialize from query props
- in Perf Filter query editor, use `key` instead of `displayName` as `filter` parameter and `filterState` object key
- fix to Attribute Query `fallbackAttribute` conversion
- conversion tool implementation of Performance `stringProperty` query. Needs work but better than previous

Need some more work for String Property conversion. For example the legacy `nodeId` may be in `FS:FI` format, but new React version looking for node id and/or host label; and legacy `resourceId` may not match React version. May need to do API lookups to fill in values correctly. However, at least the user can see the legacy values after dashboard conversion and make updates.

# External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/HELM-373
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/opennms-helm)
