### PR TITLE
Update the Grafana Slug + Validate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ commands:
             export PATH="./node_modules/.bin:${PATH}"
             curl -L -o /tmp/plugin.schema.json https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json
             sudo apt-get update
-            sudo apt-get -y install python3-pip
+            sudo apt-get -y --no-install-recommends install python3-pip
             pip3 install check-jsonschema
             check-jsonschema --schemafile /tmp/plugin.schema.json src/plugin.json
   build-and-sign:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,17 @@ commands:
           key: npm-packages-v3-{{ checksum "/tmp/filtered-package-lock.json" }}-{{ .Branch }}-{{ .Revision }}
           paths:
             - ~/.npm
+  validate-schema:
+    steps:
+      - run:
+          name: Validate Plugin Schema
+          command: |
+            export PATH="./node_modules/.bin:${PATH}"
+            curl -L -o /tmp/plugin.schema.json https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json
+            sudo apt-get update
+            sudo apt-get -y install python3-pip
+            pip3 install check-jsonschema
+            check-jsonschema --schemafile /tmp/plugin.schema.json src/plugin.json
   build-and-sign:
     steps:
       - run:
@@ -120,6 +131,7 @@ jobs:
               echo "|1|jopvDXD+uqD0jpXcT1YtIRhc8jQ=|KkoqYK0ZpHiiNZE6GBiYlI3cRmQ= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==" >> ~/.ssh/known_hosts
               chmod 600 ~/.ssh/known_hosts
       - install-node-dependencies
+      - validate-schema
       - build-and-sign
       - save-node-cache
       - store_test_results:

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,8 @@
 {
-  "extends": "./.config/.eslintrc"
+  "extends": [
+    "./.config/.eslintrc"
+  ],
+  "rules": {
+    "no-console": "off"
+  }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,0 @@
-{
-  "extends": ["@grafana/eslint-config"],
-  "rules": {
-    "no-console": "off",
-    "prettier/prettier": "off"
-  }
-}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.0'
 
 services:
   grafana:
-    container_name: 'opennms-grafana-plugin-app'
+    container_name: 'opennms-grafana-plugin'
     build:
       context: ./.config
       args:
@@ -10,5 +10,5 @@ services:
     ports:
       - 3000:3000/tcp
     volumes:
-      - ./dist:/var/lib/grafana/plugins/opennms-grafana-plugin-app
+      - ./dist:/var/lib/grafana/plugins/opennms-app
       - ./provisioning:/etc/grafana/provisioning

--- a/docs/modules/contributing/pages/developing.adoc
+++ b/docs/modules/contributing/pages/developing.adoc
@@ -22,7 +22,7 @@ Follow these steps to prepare your development environment:
 app_mode = development
 ...
 [plugins]
-allow_loading_unsigned_plugins = opennms-grafana-plugin-app
+allow_loading_unsigned_plugins = opennms-app
 ----
 
 . Use Git to check out the repository:
@@ -48,7 +48,7 @@ npm run dev
 . Symlink your `dist` directory to Grafana's plugin path:
 +
 [source, shell]
-ln -s /path/to/opennms-grafana-plugin/dist /var/lib/grafana/plugins/opennms-grafana-plugin-app
+ln -s /path/to/opennms-grafana-plugin/dist /var/lib/grafana/plugins/opennms-app
 
 . Run a continuous build that watches for changes:
 +

--- a/docs/modules/installation/pages/plugin.adoc
+++ b/docs/modules/installation/pages/plugin.adoc
@@ -21,7 +21,7 @@ Follow these steps to install the plugin using the Grafana UI:
 You can the `grafana-cli` tool to install the {product-name}:
 
 [source, shell]
-grafana-cli plugins install opennms-grafana-plugin-app
+grafana-cli plugins install opennms-app
 
 This installs the plugin in your Grafana plugins directory (default: `/var/lib/grafana/plugins`).
 For more information on `grafana-cli`, see the http://docs.grafana.org/plugins/installation/[official Grafana documentation].

--- a/docs/modules/installation/pages/source.adoc
+++ b/docs/modules/installation/pages/source.adoc
@@ -10,20 +10,20 @@ If you do not have an existing Grafana instance, see xref:package.adoc[].
 
 Follow these steps to build the plugin:
 
-. Download the source tree into a subfolder called `opennms-grafana-plugin-app` in Grafana's plugin directory:
+. Download the source tree into a subfolder called `opennms-app` in Grafana's plugin directory:
 +
 [source, shell]
 ----
 mkdir -p /var/lib/grafana/plugins
 cd /var/lib/grafana/plugins
-git clone https://github.com/OpenNMS/grafana-plugin.git opennms-grafana-plugin-app
+git clone https://github.com/OpenNMS/grafana-plugin.git opennms-app
 ----
 
 . Compile the plugin:
 +
 [source, shell]
 ----
-cd /var/lib/grafana/plugins/opennms-grafana-plugin-app
+cd /var/lib/grafana/plugins/opennms-app
 npm install
 npm run build
 ----

--- a/makezip.js
+++ b/makezip.js
@@ -21,7 +21,7 @@ const topdir = process.cwd();
 
 const version = pkginfo.version;
 
-const pkgname = 'opennms-grafana-plugin-app';
+const pkgname = 'opennms-grafana-plugin';
 const srcdir = path.join(topdir, 'dist');
 const tmpdir = path.join(topdir, 'tmp');
 const workdir = path.join(tmpdir, pkgname);

--- a/src/debian/rules
+++ b/src/debian/rules
@@ -28,5 +28,5 @@ override_dh_compress:
 
 override_dh_auto_install:
 	echo "installing"
-	install -d -m 755 debian/grafana-plugin/var/lib/grafana/plugins/opennms-grafana-plugin-app/
-	find * -maxdepth 0 | grep -vE '^debian$$' | while read LINE; do cp -pR "$$LINE" "debian/grafana-plugin/var/lib/grafana/plugins/opennms-grafana-plugin-app/$$LINE"; done
+	install -d -m 755 debian/grafana-plugin/var/lib/grafana/plugins/opennms-app/
+	find * -maxdepth 0 | grep -vE '^debian$$' | while read LINE; do cp -pR "$$LINE" "debian/grafana-plugin/var/lib/grafana/plugins/opennms-app/$$LINE"; done

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -9,8 +9,8 @@ export function initializeCss() {
   if (!cssInitialized) {
     cssInitialized = true;
     loadPluginCss({
-      dark: 'plugins/opennms-grafana-plugin-app/styles/dark.css',
-      light: 'plugins/opennms-grafana-plugin-app/styles/light.css',
+      dark: 'plugins/opennms-app/styles/dark.css',
+      light: 'plugins/opennms-app/styles/light.css',
     });
   }
 }

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "OpenNMS Plugin for Grafana",
-  "id": "opennms-grafana-plugin-app",
+  "id": "opennms-app",
   "type": "app",
   "info": {
     "description": "Create flexible dashboards using data from OpenNMS® Horizon™ and/or OpenNMS® Meridian™.",

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -43,5 +43,6 @@
     "grafanaDependency": ">=9.0.0",
     "grafanaVersion": "9.0.0",
     "plugins": []
-  }
+  },
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json"
 }


### PR DESCRIPTION
This PR changes the plugin to use `opennms-app` for the upstream/official slug, while leaving packaging alone.
Additionally, it adds the schema reference to our `plugin.json` and validates it.

# External References

* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
