### PR TITLE
HELM-408: Dashboard Conversion and Alarm Table Fixes

### DIFF
--- a/src/lib/dashboard-convert/alarmHistogramPanel.ts
+++ b/src/lib/dashboard-convert/alarmHistogramPanel.ts
@@ -1,7 +1,7 @@
 import { AlarmDirections, AlarmGroups } from '../../panels/alarm-histogram/constants'
 
 export const isLegacyAlarmHistogramPanel = (panel: any) => {
-  return panel && panel.type && panel.type === 'opennms-alarm-histogram-panel'
+  return panel && panel.type && panel.type === 'opennms-helm-alarm-histogram-panel'
 }
 
 export const convertLegacyAlarmHistogramPanel = (source: any) => {

--- a/src/lib/dashboard-convert/alarmTablePanel.ts
+++ b/src/lib/dashboard-convert/alarmTablePanel.ts
@@ -14,7 +14,7 @@ const legacyAlarmSeverityThemes = [
 ]
 
 export const isLegacyAlarmTablePanel = (panel: any) => {
-  return panel && panel.type && panel.type === 'opennms-alarm-table-panel'
+  return panel && panel.type && panel.type === 'opennms-helm-alarm-table-panel'
 }
 
 const getSeverityThemeValue = (theme: string) => {
@@ -59,7 +59,7 @@ const createOptions = (source: any) => {
   const alarmTablePaging: AlarmTablePaginationState = {
     rowsPerPage: source.pageSize || 10,
     pauseRefresh: source.pagingPausesRefresh || false,
-    scroll: source.scroll || false,
+    scroll: true, // source.scroll - force to true
     fontSize: {
       label: fontSizeLabel,
       value: fontSizeValue
@@ -188,7 +188,10 @@ const createFieldOverrides = (source: any) => {
     if (col.style.type === 'number') {
       item.properties.push({
         id: 'unit',
-        value: col.unit && col.unit === 'short' ? 'short' : 'number'
+        value: 'none'
+        // Note, setting value to 'number' results in the text 'number' after the numeric data value
+        // 'none' results in "Standard options > Unit > Number"
+        //value: col.unit && col.unit === 'short' ? 'short' : 'number'
       })
 
       if (col.style.decimals && col.style.decimals > 0) {

--- a/src/lib/dashboard-convert/datasources.ts
+++ b/src/lib/dashboard-convert/datasources.ts
@@ -11,9 +11,39 @@ interface SourceDatasourceInfo {
 }
 
 // Get datasource info from either a panel or a target
+// Legacy entries e.g. for panels, may be in various forms:
+// 1. datasource is a string:
+// "panels:" [
+//     {
+//         "datasource": "opennms-performance-datasource"
+//     }
+// ]
+//
+// 2. datasource is an object with type and uid:
+//
+// "panels:" [
+//     {
+//         "datasource": {
+//             "type": "opennms-performance-datasource",
+//             "uid": "ab1z3q4d"
+//         }
+//     }
+// ]
+//
+// 3. datasource is an object with just uid, and uid is a string or template variable
+//
+// "panels:" [
+//     {
+//         "datasource": {
+//             "uid": "$datasource"
+//         }
+//     }
+// ]
+//
 export const getSourceDatasourceInfo = (source: any, datasourceMap: Map<string,DsType>): SourceDatasourceInfo => {
   if (source && source.datasource) {
     if (isString(source.datasource) && datasourceMap.has(source.datasource)) {
+      // 1. datasource is a string
       const dsType = datasourceMap.get(source.datasource) || ''
 
       return {
@@ -22,6 +52,7 @@ export const getSourceDatasourceInfo = (source: any, datasourceMap: Map<string,D
         datasourceType: dsType
       }
     } else if (!isString(source.datasource) && source.datasource?.type) {
+      // 2. datasource is an object with type
       const { datasourceType } = getDatasourceTypeFromPluginId(source.datasource.type)
 
       if (datasourceType) {
@@ -31,7 +62,19 @@ export const getSourceDatasourceInfo = (source: any, datasourceMap: Map<string,D
           datasourceType
         }
       }
-   }
+    } else if (!isString(source.datasource) && !source.datasource?.type && source.datasource?.uid) {
+      // 3. datasource is an object with uid only
+      const uid: string = source.datasource.uid || ''
+      const dsType = datasourceMap.get(uid)
+
+      if (dsType) {
+        return {
+          isOpenNmsDatasource: true,
+          isTemplateVariable: uid.startsWith('$'),
+          datasourceType: dsType
+        }
+      }
+    }
   }
 
   return {

--- a/src/lib/dashboard-convert/entityDs.ts
+++ b/src/lib/dashboard-convert/entityDs.ts
@@ -40,7 +40,7 @@ export const updateEntityQuery = (source: any) => {
   //   name: "Category: Name",
   // }
 
-  const columns = getColumns(target.entityType.label)
+  const columns = getColumns(target.entityType?.label || target.entityType?.id)
 
   target.clauses = (target.filter?.clauses || []).map((c, i) => {
     const attrLabel = c.restriction.attribute // 'label'

--- a/src/lib/dashboard-convert/filterPanel.ts
+++ b/src/lib/dashboard-convert/filterPanel.ts
@@ -1,7 +1,7 @@
 import { DatasourceMetadata, DsType } from './types'
 
 export const isLegacyFilterPanel = (panel: any) => {
-  return panel && panel.type && panel.type === 'opennms-filter-panel'
+  return panel && panel.type && panel.type === 'opennms-helm-filter-panel'
 }
 
 // NOTE: Selected Filter Panel values will be lost, as they are now saved in

--- a/src/lib/dashboard-convert/flowHistogramPanel.ts
+++ b/src/lib/dashboard-convert/flowHistogramPanel.ts
@@ -8,7 +8,7 @@ import {
 import { FlowHistogramOptionsProps } from '../../panels/flow-histogram/FlowHistogramTypes'
 
 export const isLegacyFlowHistogramPanel = (panel: any) => {
-  return panel && panel.type && panel.type === 'opennms-flow-histogram-panel'
+  return panel && panel.type && panel.type === 'opennms-helm-flow-histogram-panel'
 }
 
 export const convertLegacyFlowHistogramPanel = (source: any) => {

--- a/src/lib/dashboard-convert/panels.ts
+++ b/src/lib/dashboard-convert/panels.ts
@@ -49,6 +49,7 @@ const convertPanelDatasources = (panel: any, datasourceMap: Map<string, DsType>,
   // - a template variable like '$datasource' which points to an OpenNMS DS
   //    in which case we leave as-is
   // - an object like { type, uid }, which points to an OpenNMS DS, in which case we update it to version 9
+  // - an object like { uid }, which contains an OpenNMS DS type or template variable, in which case we leave it alone
   // - either of those which points to a non-OpenNMS DS, in which case leave as-is
   // - empty/null/undefined, in which case DS should be in the individual targets, leave as-is
   const panelDsInfo = getSourceDatasourceInfo(panel, datasourceMap)

--- a/src/lib/dashboard-convert/utils.ts
+++ b/src/lib/dashboard-convert/utils.ts
@@ -12,7 +12,7 @@ export const addVariationsToMap = (varName: string, dsType: DsType,  datasourceM
 // returns a string which is one of the DsTypes or else empty string, and
 // whether this is a "legacy" datasource or not (legacy is version < 9)
 export const getDatasourceTypeFromPluginId = (pluginId: string) => {
-  const legacyMatch = pluginId.match(/^opennms-([^-]+)-datasource$/i)
+  const legacyMatch = pluginId.match(/^opennms-helm-([^-]+)-datasource$/i)
 
   if (legacyMatch && legacyMatch.length > 0) {
     return {


### PR DESCRIPTION
Fixes to dashboard conversion code plus some Alarm Table fixes.

- added back `helm` to conversion code that looks for legacy datasources and panels (this had been inadvertently removed)
- force Alarm Table conversion for scrolling to be true (more often that not, horizontal scroll will be needed to display all columns)
- fix Alarm Table number conversion, it's actually `none` instead of `number`
- handle case where legacy datasource has `uid` of a template variable but no `type`
- fix null reference issue

# External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/HELM-408
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
