### PR TITLE
HELM-398: Enable 'Use Grafana user' in Alarm Table Panel

### DIFF
--- a/src/panels/alarm-table/AlarmTableAdditional.tsx
+++ b/src/panels/alarm-table/AlarmTableAdditional.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useState } from 'react'
+import {
+  InlineField,
+  InlineFieldRow,
+  Switch
+} from '@grafana/ui'
+import { AlarmTableAdditionalState } from './AlarmTableTypes'
+
+interface AlarmTableAdditionalProps {
+    onChange: Function;
+    context: any;
+}
+
+export const AlarmTableAdditional: React.FC<AlarmTableAdditionalProps> = ({ onChange, context }) => {
+    const [alarmTableAdditional, setAlarmTableAdditional] = useState<AlarmTableAdditionalState>(context?.options?.alarmTable?.alarmTableAdditional || 
+      { useGrafanaUser: false })
+    const tooltipText = 'Used to control whether operations on alarms are performed the data source user, ' +
+      'or the user that is currently logged in to Grafana. ' +
+      'Supported operations are escalating, clearing, un-acknowledging alarms ' +
+      'as well as creating/updating a journal/memo. ' +
+      'NOTE: The data source must be configured using an user with the \'admin\' role ' +
+      'in order to perform actions as other users.'
+
+    useEffect(() => {
+        onChange(alarmTableAdditional);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [alarmTableAdditional])
+
+    const setAlarmTableState = (key, value) => {
+        const newState = { ...alarmTableAdditional }
+        newState[key] = value
+        setAlarmTableAdditional(newState)
+   }
+
+    return (
+      <div>
+        <InlineFieldRow>
+          <InlineField label='Use Grafana user' tooltip={tooltipText}>
+            <div style={{ display: 'flex', alignItems: 'center', height: '32px' }}>
+              <Switch
+                value={alarmTableAdditional.useGrafanaUser}
+                onChange={() => setAlarmTableState('useGrafanaUser', !alarmTableAdditional.useGrafanaUser)} />
+            </div>
+          </InlineField>
+        </InlineFieldRow>
+      </div>
+  )
+}

--- a/src/panels/alarm-table/AlarmTableControl.tsx
+++ b/src/panels/alarm-table/AlarmTableControl.tsx
@@ -24,7 +24,9 @@ export const AlarmTableControl: React.FC<PanelProps<AlarmTableControlProps>> = (
     const { client } = useOpenNMSClient(props.data?.request?.targets?.[0]?.datasource)
     const { filteredProps, page, setPage, totalPages } = useAlarmProperties(props?.data?.series[0], props?.options?.alarmTable)
     const { table, menu, menuOpen, setMenuOpen } = useAlarmTableMenu(rowClicked, filteredProps)
-    const { actions, detailsModal, setDetailsModal } = useAlarmTableMenuActions(state.indexes, props?.data?.series?.[0].fields, () => setMenuOpen(false), client)
+    const { actions, detailsModal, setDetailsModal } = useAlarmTableMenuActions(state.indexes,
+      props?.data?.series?.[0].fields, () => setMenuOpen(false),
+      props?.options?.alarmTable?.alarmTableAdditional?.useGrafanaUser || false, client)
     const { tabActive, tabClick, resetTabs } = useAlarmTableModalTabs()
     const { alarm, goToAlarm, alarmQuery } = useAlarm(props?.data?.series, soloIndex, client)
 

--- a/src/panels/alarm-table/AlarmTableData.tsx
+++ b/src/panels/alarm-table/AlarmTableData.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Select } from '@grafana/ui'
 import { DragList } from 'components/DragList'
 import { OnmsInlineField } from 'components/OnmsInlineField'

--- a/src/panels/alarm-table/AlarmTableOptions.tsx
+++ b/src/panels/alarm-table/AlarmTableOptions.tsx
@@ -1,29 +1,32 @@
 import React, { useEffect, useState } from 'react'
+import { PanelOptionsEditorProps } from '@grafana/data'
+import { AlarmTableAdditional } from './AlarmTableAdditional'
+import { AlarmTableAlarms } from './AlarmTableAlarms'
 import { AlarmTableData } from './AlarmTableData'
 import { AlarmTablePaging } from './AlarmTablePaging'
-import { AlarmTableAlarms } from './AlarmTableAlarms'
-import { PanelOptionsEditorProps } from '@grafana/data'
 
 export const AlarmTableOptions: React.FC<PanelOptionsEditorProps<{}>> = ({ context, onChange }) => {
-    const [internalOptions, setInternalOptions] = useState({})
-    const onOptionChange = (v, k) => {
-        setInternalOptions((oldOptions) => {
-            const newOptions = { ...oldOptions }
-            newOptions[k] = v
-            return newOptions
-        })
-    }
+  const [internalOptions, setInternalOptions] = useState({})
 
-    useEffect(() => {
-        onChange(internalOptions)
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [internalOptions])
+  const onOptionChange = (v, k) => {
+    setInternalOptions((oldOptions) => {
+      const newOptions = { ...oldOptions }
+      newOptions[k] = v
+      return newOptions
+    })
+  }
 
-    return (
-        <>
-            <AlarmTableData context={context} onChange={(v) => onOptionChange(v, 'alarmTableData')} />
-            <AlarmTablePaging context={context} onChange={(v) => onOptionChange(v, 'alarmTablePaging')} />
-            <AlarmTableAlarms onChange={(v) => onOptionChange(v, 'alarmTableAlarms')} alarmTable={context.options?.alarmTable} />
-        </>
-    )
+  useEffect(() => {
+    onChange(internalOptions)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [internalOptions])
+
+  return (
+    <>
+      <AlarmTableAdditional context={context} onChange={(v) => onOptionChange(v, 'alarmTableAdditional')} />
+      <AlarmTableData context={context} onChange={(v) => onOptionChange(v, 'alarmTableData')} />
+      <AlarmTablePaging context={context} onChange={(v) => onOptionChange(v, 'alarmTablePaging')} />
+      <AlarmTableAlarms onChange={(v) => onOptionChange(v, 'alarmTableAlarms')} alarmTable={context.options?.alarmTable} />
+    </>
+  )
 }

--- a/src/panels/alarm-table/AlarmTableTypes.ts
+++ b/src/panels/alarm-table/AlarmTableTypes.ts
@@ -1,38 +1,43 @@
 import { SelectableValue } from '@grafana/data'
 
 export interface AlarmTableControlState {
-    indexes: boolean[];
-    lastClicked: number;
+  indexes: boolean[]
+  lastClicked: number
+}
+
+export interface AlarmTableAdditionalState {
+  useGrafanaUser: boolean
 }
 
 export interface AlarmTableAlarmDataState {
-    styleWithSeverity?: SelectableValue<string | number>,
-    severityTheme?: SelectableValue<string | number>
+  styleWithSeverity?: SelectableValue<string | number>
+  severityTheme?: SelectableValue<string | number>
 }
 
 export interface AlarmTableDataState {
-    transformType?: SelectableValue<string | number>;
-    columns: Array<SelectableValue<string | number>>
+  transformType?: SelectableValue<string | number>
+  columns: Array<SelectableValue<string | number>>
 }
 
 export interface AlarmTablePaginationState {
-    rowsPerPage?: number;
-    pauseRefresh: boolean;
-    scroll: boolean;
-    fontSize?: SelectableValue<string | number>
+  rowsPerPage?: number
+  pauseRefresh: boolean
+  scroll: boolean
+  fontSize?: SelectableValue<string | number>
 }
 
 export interface AlarmTableControlProps {
-    alarmTable: {
-        alarmTableAlarms: AlarmTableAlarmDataState,
-        alarmTableData: AlarmTableAlarmDataState,
-        alarmTablePaging: AlarmTablePaginationState
-    };
+  alarmTable: {
+    alarmTableAdditional: AlarmTableAdditionalState,
+    alarmTableAlarms: AlarmTableAlarmDataState,
+    alarmTableData: AlarmTableAlarmDataState,
+    alarmTablePaging: AlarmTablePaginationState
+  }
 }
 
 export interface AlarmTableControlActions {
-    clear: () => void;
-    escalate: () => void;
-    acknowledge: () => void;
-    details: () => void;
+  clear: () => void
+  escalate: () => void
+  acknowledge: () => void
+  details: () => void
 }

--- a/src/panels/alarm-table/hooks/useAlarmTableMenuActions.ts
+++ b/src/panels/alarm-table/hooks/useAlarmTableMenuActions.ts
@@ -4,52 +4,63 @@ import { getBackendSrv } from '@grafana/runtime'
 import { ClientDelegate } from 'lib/client_delegate'
 import { getAlarmIdFromFields } from '../AlarmTableHelper'
 
-export const useAlarmTableMenuActions = (indexes: boolean[], fields: Field[], closeMenu, client: ClientDelegate | undefined) => {
-    const [detailsModal, setDetailsModal] = useState(false)
-    const [user, setUser] = useState<{ id: string }>()
+export const useAlarmTableMenuActions = (indexes: boolean[], fields: Field[],
+  closeMenu, useGrafanaUser: boolean, client: ClientDelegate | undefined) => {
+  const [detailsModal, setDetailsModal] = useState(false)
+  // 'id' is the Grafana user id, this doesn't correlate to anything in OpenNMS
+  // 'login' should match OpenNMS username
+  const [user, setUser] = useState<{ id: string, login: string }>()
 
-    useEffect(() => {
-        const getUserFromGrafana = async () => {
-            setUser((await getBackendSrv().get('/api/users'))?.[0])
-        }
-
-        getUserFromGrafana()
-    }, [])
-
-    const loopAction = async (action) => {
-        for (let i = 0; i < indexes.length; i++) {
-            if (indexes[i]) {
-                const alarmId = getAlarmIdFromFields(fields, i)
-                await action(alarmId, user?.id)
-            }
-        }
+  useEffect(() => {
+    const getUserFromGrafana = async () => {
+      if (useGrafanaUser) {
+        // Grafana 'Get Actual User' API to get current user
+        const apiUser = await getBackendSrv().get('/api/user')
+        setUser(apiUser)
+      } else {
+        // unset user to use the user configured in the Entity datasource  
+        setUser(undefined)
+      }
     }
 
-    const clear = async () => {
-        await loopAction(async (alarmId, userId) => {
-            await client?.doClear(alarmId, user?.id)
-        })
-        closeMenu()
-    }
+    getUserFromGrafana()
+  }, [useGrafanaUser])
 
-    const details = () => {
-        closeMenu()
-        setDetailsModal(true)
-    }
 
-    const escalate = async () => {
-        await loopAction(async (alarmId, userId) => {
-            await client?.doEscalate(alarmId, user?.id)
-        })
-        closeMenu()
+  const loopAction = async (action) => {
+    for (let i = 0; i < indexes.length; i++) {
+      if (indexes[i]) {
+        const alarmId = getAlarmIdFromFields(fields, i)
+        await action(alarmId, user?.login)
+      }
     }
+  }
 
-    const acknowledge = async () => {
-        await loopAction(async (alarmId, userId) => {
-            await client?.doAck(alarmId, user?.id)
-        })
-        closeMenu()
-    }
+  const clear = async () => {
+    await loopAction(async (alarmId, userId) => {
+      await client?.doClear(alarmId, user?.login)
+    })
+    closeMenu()
+  }
 
-    return { actions: { clear, details, escalate, acknowledge }, detailsModal, setDetailsModal }
+  const details = () => {
+    closeMenu()
+    setDetailsModal(true)
+  }
+
+  const escalate = async () => {
+    await loopAction(async (alarmId, userId) => {
+      await client?.doEscalate(alarmId, user?.login)
+    })
+    closeMenu()
+  }
+
+  const acknowledge = async () => {
+    await loopAction(async (alarmId, userId) => {
+      await client?.doAck(alarmId, user?.login)
+    })
+    closeMenu()
+  }
+
+  return { actions: { clear, details, escalate, acknowledge }, detailsModal, setDetailsModal }
 }


### PR DESCRIPTION
Enable a "Use Grafana user" switch for the Alarm Table Panel.

It's set in the Alarm Table Options panel. If set, it will send the username of the currently logged-in Grafana user as the user for alarm ack and other actions. Otherwise, the user is left "unset", in which case the user that is configured in the Entity Datasource will be used.

In Helm 8, the control for this was in the Entity Datasource options; however since we actually call the OpenNMS alarm API from Alarm Table Panel code, I put the "Use Grafana user" switch in the Alarm Table Panel options.

Also as a note, we use the Grafana "Actual user" API which returns info about the current logged-in Grafana user. This includes an `id` which is an integer value assigned by Grafana that has nothing to do with OpenNMS, and a `login` string field, which should correspond to an OpenNMS username; we use `login`.


# External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/HELM-398
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
