### PR TITLE
HELM-406: Adding a perf filter query to a dashboard elicits "TypeError: l is undefined"

### DIFF
--- a/src/datasources/perf-ds/PerformanceFilter.tsx
+++ b/src/datasources/perf-ds/PerformanceFilter.tsx
@@ -25,7 +25,7 @@ export interface PerformanceFilterProps {
 
 export const PerformanceFilter: React.FC<PerformanceFilterProps> = ({ query, updateQuery, loadFilters }) => {
     const [filter, setFilter] = useState<SelectableValue<FilterResponse>>(query.filter);
-    const [filterState, setFilterState] = useState<Record<string, {value: any, filter: any}>>(query.filterState);
+    const [filterState, setFilterState] = useState<Record<string, {value: any, filter: any}>>(query.filterState || {});
 
     const updateFilterState = (propertyName: string, value: {value: any, filter: any}) => {
         setFilterState({ ...filterState, [propertyName]: value })
@@ -59,8 +59,8 @@ export const PerformanceFilter: React.FC<PerformanceFilterProps> = ({ query, upd
                                 <Segment
                                     placeholder={param.key}
                                     value={filterState[param.key]?.value || false}
-                                    onChange={(value: unknown) => {
-                                        updateFilterState(param.key, { value, filter: param })
+                                    onChange={(value: SelectableValue<string>) => {
+                                        updateFilterState(param.key, { value: value?.value, filter: param })
                                     }}
                                     options={[{ label: 'True', value: 'true'}, { label: 'False', value: 'false' }]}
                                 />

--- a/src/datasources/perf-ds/queries/queryBuilder.ts
+++ b/src/datasources/perf-ds/queries/queryBuilder.ts
@@ -109,8 +109,8 @@ export const buildAttributeQuerySource = (target: PerformanceQuery) => {
         resourceId: resourceId.replace('node[', 'nodeSource['),
         attribute: attribute,
         ['fallback-attribute']: target.attribute.fallbackAttribute?.name || undefined,
-        aggregation: target.attribute.aggregation?.label?.toUpperCase() || 'AVERAGE',
-        transient: target.hide 
+        aggregation: target.attribute.aggregation?.label?.toUpperCase() || undefined,
+        transient: target.hide === null || target.hide === undefined ? false: true
     } as OnmsMeasurementsQuerySource
 
     return source;
@@ -120,7 +120,7 @@ export const buildExpressionQuery = (target: PerformanceQuery, index: number) =>
     const expression = {
         label: target.label || 'expression' + index,
         value: target.expression,
-        transient: target.hide 
+        transient: target.hide === null || target.hide === undefined ? false: true
     } as OnmsMeasurementsQueryExpression
 
     return expression


### PR DESCRIPTION
fix: resolve the error in performance Filter datasource

# Pull Request Check Sheet

* [ ] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [ ] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [ ] Have you made a comment in that issue which points back to this PR?
* [ ] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [ ] If this is a new feature, is there documentation?
* [ ] If this is a new feature or substantial change, are there tests that cover it?

# Pull Request Process

One or more reviewers should be assigned to each PR.

If you know that a particular person is subject matter expert in the area your PR affects, feel free to assign one or more reviewers when you create this PR, otherwise reviewers will be assigned for you.

Once the reviewer(s) accept the PR and the branch passes continuous integration in Bamboo, the PR is eligible for merge.

At that time, if you have commit access (are an OpenNMS Group employee or a member of the Order of the Green Polo) you are welcome to merge the PR.
Otherwise, a reviewer can merge it for you.

Thanks for taking time to contribute!

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/HELM-406
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
