### PR TITLE
HELM-411: Alarm datasource query not keeping proper equality

### DIFF
--- a/src/datasources/entity-ds/EntityClause.tsx
+++ b/src/datasources/entity-ds/EntityClause.tsx
@@ -20,25 +20,24 @@ export const EntityClause = ({
 }: EntityClauseProps) => {
 
     const createComparatorOptions = () => {
-      return Object.keys(API.Comparators).map(key => API.Comparators[key])
+        return Object.keys(API.Comparators).map(key => API.Comparators[key])
     }
 
     const [comparatorOptions, setComparatorOptions] = useState<Array<SelectableValue<Comparator>>>(createComparatorOptions());
     const [comparedOptions, setComparedOptions] = useState<Array<SelectableValue<string>>>([]);
 
     useEffect(() => {
-      const { values, comparators } = getValuesAndComparatorsFromClause();
+        const { values, comparators } = getValuesAndComparatorsFromClause();
 
-      if (values) {
-          buildOptionsFromAttributeValues(values);
-      }
+        if (values) {
+            buildOptionsFromAttributeValues(values);
+        }
 
-      if (comparators) {
-          setComparatorOptions(comparators)
-          setComparator(index, comparators[0])
-      }
+        if (comparators) {
+            setComparatorOptions(comparators)
+        }
 
-      // eslint-disable-next-line react-hooks/exhaustive-deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [clause.attribute])
 
     const buildOptionsFromAttributeValues = (values: string[]) => {
@@ -80,8 +79,9 @@ export const EntityClause = ({
             dispatchClauses({ type: ClauseActionType.delete, index: col })
         }
         else {
+            const comp = API.Comparators.EQ
             setAttribute(col, {})
-            setComparator(col, {})
+            setComparator(col, { label: comp.label, value: comp })
             setComparedString(col, '')
             setComparedValue(col, {})
         }


### PR DESCRIPTION
fix: issue when creating a query, then saving the query and reopen in edit mode it resets equality to default EQ.
Now should work accordingly setting the equality to the corresponding from the original query.

# Pull Request Check Sheet

* [ ] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [ ] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [ ] Have you made a comment in that issue which points back to this PR?
* [ ] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [ ] If this is a new feature, is there documentation?
* [ ] If this is a new feature or substantial change, are there tests that cover it?

# Pull Request Process

One or more reviewers should be assigned to each PR.

If you know that a particular person is subject matter expert in the area your PR affects, feel free to assign one or more reviewers when you create this PR, otherwise reviewers will be assigned for you.

Once the reviewer(s) accept the PR and the branch passes continuous integration in Bamboo, the PR is eligible for merge.

At that time, if you have commit access (are an OpenNMS Group employee or a member of the Order of the Green Polo) you are welcome to merge the PR.
Otherwise, a reviewer can merge it for you.

Thanks for taking time to contribute!

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/HELM-411
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
