### PR TITLE
HELM-421: Fix, nodeId passed to templateSrv.replace must be a string

### DIFF
--- a/src/datasources/perf-ds/queries/queryStringProperties.ts
+++ b/src/datasources/perf-ds/queries/queryStringProperties.ts
@@ -49,6 +49,7 @@ export const getDefinedStringPropertyQueries = (templateSrv: TemplateSrv, reques
         .map(q => {
             const nodeId = q.stringPropertyState.node.id || q.stringPropertyState.node.label
             const resourceId = q.stringPropertyState.resource.id || q.stringPropertyState.resource.label
+
             return {
                 //...q,
                 // DataQuery fields
@@ -59,7 +60,7 @@ export const getDefinedStringPropertyQueries = (templateSrv: TemplateSrv, reques
                 datasource: q.datasource,
 
                 // StringPropertyQuery fields
-                nodeId: trimChar(templateSrv.replace(nodeId, request.scopedVars), '{', '}'),
+                nodeId: trimChar(templateSrv.replace('' + nodeId, request.scopedVars), '{', '}'),
                 resourceId: trimChar(templateSrv.replace(getResourceId(resourceId), request.scopedVars), '{', '}'),
                 stringProperty: q.stringPropertyState.stringProperty.value
             } as DefinedStringPropertyQuery


### PR DESCRIPTION
Grafana reviewer reported this. Grafana `TemplateSrv.replace` calls `string.replace` on the `target` variable, expecting it to be a string, but we were passing `nodeId` as a `number`. Coerced it to a string.

# External References

* JIRA (Issue Tracker): [http://issues.opennms.org/browse/${JIRA-ISSUE-NUMBER}](https://opennms.atlassian.net/browse/HELM-421)
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
