### PR TITLE
HELM-389: Filter Panel, tie to dashboard

### DIFF
--- a/src/datasources/entity-ds/EntityDataSource.ts
+++ b/src/datasources/entity-ds/EntityDataSource.ts
@@ -57,9 +57,11 @@ export class EntityDataSource extends DataSourceApi<EntityQuery> {
         //   localStorage. May be able to subscribe to EventBus
 
         // get data from any FilterPanels that may be active
-        const filterEditorData = loadFilterEditorData()
+        const dashboardUid = request.dashboardUID || ''
+        const filterEditorData = dashboardUid ? loadFilterEditorData(dashboardUid) : null
+
         const hasFilterEditorData = (filterEditorData &&
-            filterEditorData?.activeFilters.length > 0 && filterEditorData?.selectableValues.length > 0)
+            filterEditorData.activeFilters.length > 0 && filterEditorData.selectableValues.length > 0)
 
         for (let target of request.targets) {
             request.entityType = target?.selectType?.label || EntityTypes.Alarms

--- a/src/datasources/entity-ds/types.ts
+++ b/src/datasources/entity-ds/types.ts
@@ -177,13 +177,20 @@ export interface FilterSelectableValues {
 }
 
 /**
- * FilterPanel data saved to localStorage for use by Entity Datasource.
+ * FilterPanel data for one dashboard saved to localStorage for use by Entity Datasource.
  */
 export interface FilterEditorData {
-  datasource: SelectableValue<GrafanaDatasource> | undefined,
+  dashboardUid: string
+  datasource: SelectableValue<GrafanaDatasource> | undefined
   activeFilters: ActiveFilter[]
   selectableValues: FilterSelectableValues[]
 }
+
+/**
+ * FilterPanel data for all dashboards, saved to localStorage for use by Entity Datasource.
+ * Record key is dashboard uid.
+ */
+export type FilterEditorDataCollection = Record<string, FilterEditorData>
 
 export type OnmsRow = Array<number | string | moment.Moment | boolean | undefined>
 
@@ -199,7 +206,6 @@ export type Action =
   { type: ClauseActionType.addNestedClause, index: number } |
   { type: ClauseActionType.delete, index: number }
 
-
 /**
  * Type of action allowed
  */
@@ -211,5 +217,3 @@ export enum ClauseActionType {
   delete,
   update
 }
-
-

--- a/src/lib/localStorageService.ts
+++ b/src/lib/localStorageService.ts
@@ -1,4 +1,75 @@
-import { FilterEditorData } from '../datasources/entity-ds/types'
+import { FilterEditorData, FilterEditorDataCollection } from '../datasources/entity-ds/types'
+
+const FILTER_PANEL_STORAGE_KEY = 'opennms-filter-panel'
+
+// save FilterEditorData for all dashboards, used internally
+const saveAllFilterEditorData = (data: FilterEditorDataCollection) => {
+  localStorage.setItem(FILTER_PANEL_STORAGE_KEY, JSON.stringify(data, getCircularReplacer()))
+}
+
+// load FilterEditorData for all dashboards, used internally
+const loadAllFilterEditorData = (): FilterEditorDataCollection | null => {
+    const json = localStorage.getItem(FILTER_PANEL_STORAGE_KEY)
+
+    if (json) {
+        const data = JSON.parse(json)
+        
+        if (data) {
+          return data as FilterEditorDataCollection
+        }
+    }
+
+    return null
+}
+
+// save filter editor data for a specific dashboard (data.dashboardUid contains id)
+export const saveFilterEditorData = (data: FilterEditorData) => {
+  if (!data || !data.dashboardUid) {
+    throw new Error('Cannot save filter editor data: no dashboard uid.')
+  }
+
+  const existingData = loadAllFilterEditorData()
+  const newData = { ...existingData, [data.dashboardUid]: data }
+  localStorage.setItem(FILTER_PANEL_STORAGE_KEY, JSON.stringify(newData, getCircularReplacer()))
+}
+
+export const loadFilterEditorData = (dashboardUid: string): FilterEditorData | null => {
+  if (!dashboardUid) {
+    throw new Error('Cannot load filter editor data: no dashboard uid.')
+  }
+
+  const allData = loadAllFilterEditorData()
+
+  if (allData) {
+    const data = allData[dashboardUid]
+    return data
+  }
+
+  return null
+}
+
+// remove filter data for the given dashboard
+export const removeDashboardFilterEditorData = (dashboardUid: string) => {
+  if (!dashboardUid) {
+    throw new Error('Cannot remove filter editor data: no dashboard uid.')
+  }
+
+  const json = localStorage.getItem(FILTER_PANEL_STORAGE_KEY)
+
+  if (json) {
+      const data = JSON.parse(json) as FilterEditorDataCollection
+
+      if (Object.keys(data).includes(dashboardUid)) {
+        delete data[dashboardUid]
+        saveAllFilterEditorData(data)
+      }
+  }
+}
+
+// clears all filter data for all dashboards
+export const clearFilterEditorData = () => {
+  localStorage.removeItem(FILTER_PANEL_STORAGE_KEY)
+}
 
 const getCircularReplacer = () => {
     const seen = new WeakSet()
@@ -12,25 +83,4 @@ const getCircularReplacer = () => {
         }
         return value
     }
-}
-
-const FILTER_PANEL_STORAGE_KEY = 'opennms-filter-panel'
-
-export const saveFilterEditorData = (data: FilterEditorData) => {
-    localStorage.setItem(FILTER_PANEL_STORAGE_KEY, JSON.stringify(data, getCircularReplacer()))
-}
-
-export const loadFilterEditorData = (): FilterEditorData | null => {
-    const json = localStorage.getItem(FILTER_PANEL_STORAGE_KEY)
-
-    if (json) {
-        const filterPanel = JSON.parse(json)
-        return filterPanel as FilterEditorData
-    }
-
-    return null
-}
-
-export const clearFilterEditorData = () => {
-  localStorage.removeItem(FILTER_PANEL_STORAGE_KEY)
 }

--- a/src/panels/filter-panel/FilterPanelControl.tsx
+++ b/src/panels/filter-panel/FilterPanelControl.tsx
@@ -27,7 +27,8 @@ export const FilterPanelControl: React.FC<PanelProps<FilterControlProps>> = (pro
     const [selectableValues, setSelectableValues] = useState<FilterSelectableValues[]>([])
 
     useEffect(() => {
-        const filterEditorData = loadFilterEditorData()
+        const dashboardUid = props.data.request?.dashboardUID || ''
+        const filterEditorData = dashboardUid ? loadFilterEditorData(dashboardUid) : null
 
         if (filterEditorData && filterEditorData.selectableValues) {
             setSelectableValues(filterEditorData.selectableValues)
@@ -195,8 +196,13 @@ export const FilterPanelControl: React.FC<PanelProps<FilterControlProps>> = (pro
      */
     const saveFilterPanel = (filterSelectableValues: FilterSelectableValues[]) => {
         if (props.options.filterEditor) {
-            // TODO: May want to remove some data from datasource before saving
+            const dashboardUid = props.data.request?.dashboardUID || ''
+
+            // store this in options so FilterPanelOptions can retrieve it
+            props.options.dashboardUid = dashboardUid
+
             const filterData: FilterEditorData = {
+                dashboardUid,
                 ...props.options.filterEditor,
                 selectableValues: filterSelectableValues
             }

--- a/src/panels/filter-panel/FilterPanelOptions.tsx
+++ b/src/panels/filter-panel/FilterPanelOptions.tsx
@@ -31,13 +31,17 @@ export const FilterPanelOptions: React.FC<PanelOptionsEditorProps<FilterPanelOpt
     }
 
     useEffect(() => {
-        const data = loadFilterEditorData()
+        const dashboardUid = props.context.options?.dashboardUid || ''
 
-        if (data && data.datasource && data.activeFilters) {
-            setInternalOptions({
-                datasource: data.datasource,
-                activeFilters: data.activeFilters
-            })
+        if (dashboardUid) {
+          const data = loadFilterEditorData(dashboardUid)
+
+          if (data && data.datasource && data.activeFilters) {
+              setInternalOptions({
+                  datasource: data.datasource,
+                  activeFilters: data.activeFilters
+              })
+          }
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])

--- a/src/panels/filter-panel/FilterPanelTypes.ts
+++ b/src/panels/filter-panel/FilterPanelTypes.ts
@@ -3,6 +3,7 @@ import { GrafanaDatasource } from 'hooks/useDataSources'
 import { ActiveFilter } from '../../datasources/entity-ds/types'
 
 export interface FilterControlProps {
+    dashboardUid?: string
     filterEditor: {
         datasource: SelectableValue<GrafanaDatasource> | undefined,
         activeFilters: ActiveFilter[]


### PR DESCRIPTION
Tie local storage for Filter Panels to the dashboard they are on. Entity Datasource will load proper filter settings for the dashboard it's being called by. This allows multiple dashboards with their own Filter Panel to work simultaneously.

May need a little more runtime testing but is generally working.

Also, ideally local storage for a dashboard would be removed when a dashboard is deleted, was unable to find a hook for doing this. User can always clear all Filter Panel local storage data from buttons within Filter Panel Options or Entity Datasource configuration.

# External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/HELM-389
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
