### PR TITLE
HELM-424, HELM-425: Fix transient flag logic in Perf DS queries, node selection

### DIFF
--- a/src/datasources/perf-ds/PerformanceAttribute.tsx
+++ b/src/datasources/perf-ds/PerformanceAttribute.tsx
@@ -60,8 +60,8 @@ export const PerformanceAttribute: React.FC<PerformanceAttributesProps> = ({
       const node = propertyValue as PerformanceAttributeItemState
 
       const resourceOptions: OnmsResourceDto[] = await loadResourcesByNode(node.id || node.label)
-      const existingLabel = performanceState.resource.label
-      const resource = (existingLabel && resourceOptions.filter(r => r.label === existingLabel)?.[0]) || {}
+      const existingLabel = performanceState?.resource?.label
+      const resource = (existingLabel && resourceOptions && resourceOptions.filter(r => r.label === existingLabel)?.[0]) || {}
 
       const state = {
         ...performanceState,

--- a/src/datasources/perf-ds/queries/queryBuilder.ts
+++ b/src/datasources/perf-ds/queries/queryBuilder.ts
@@ -44,10 +44,10 @@ export const isValidMeasurementQuery = (query: OnmsMeasurementsQueryRequest) => 
 
 export const isValidAttributeTarget = (target: PerformanceQuery) => {
     if (!target ||
-        !(target.attribute &&
-          (target.attribute.attribute.name || (target.attribute.attribute.label && OpenNMSGlob.hasGlob(target.attribute.attribute.label))) &&
-          (target.attribute.resource.id || target.attribute.resource.label) &&
-          (target.attribute.node.id || target.attribute.node.label))) {
+        !target.attribute ||
+        !((target.attribute.attribute?.name || (target.attribute.attribute?.label && OpenNMSGlob.hasGlob(target.attribute.attribute?.label))) &&
+          (target.attribute.resource?.id || target.attribute.resource?.label) &&
+          (target.attribute.node?.id || target.attribute.node?.label))) {
         return false
     }
 

--- a/src/datasources/perf-ds/queries/queryBuilder.ts
+++ b/src/datasources/perf-ds/queries/queryBuilder.ts
@@ -119,7 +119,7 @@ export const buildAttributeQuerySource = (target: PerformanceQuery) => {
         attribute: attribute,
         ['fallback-attribute']: target.attribute.fallbackAttribute?.name || undefined,
         aggregation: target.attribute.aggregation?.label?.toUpperCase() || undefined,
-        transient: target.hide === null || target.hide === undefined ? false: true
+        transient: target.hide === true
     } as OnmsMeasurementsQuerySource
 
     return source;
@@ -129,7 +129,7 @@ export const buildExpressionQuery = (target: PerformanceQuery, index: number) =>
     const expression = {
         label: target.label || 'expression' + index,
         value: target.expression,
-        transient: target.hide === null || target.hide === undefined ? false: true
+        transient: target.hide === true
     } as OnmsMeasurementsQueryExpression
 
     return expression


### PR DESCRIPTION
HELM-425: Fix logic for sending `transient: true` in Performance data source Measurement API queries. Should only be sent when a query has been flagged as `hidden`.

Previous logic resulted in `transient: true` almost always being sent, resulting in `204: No Content` responses, making it appear that Performance data source was not working at all.

HELM-424: Fix some issues which caused user to not be able to select a node from the Node dropdown in a Performance query.

# External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/HELM-424,
* https://opennms.atlassian.net/browse/HELM-425
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
