### PR TITLE
HELM-414: Fix PerfDS label conversion, add 'requires' conversion

### DIFF
--- a/src/lib/dashboard-convert/convert.ts
+++ b/src/lib/dashboard-convert/convert.ts
@@ -1,6 +1,7 @@
 import { getDataSourceSrv } from '@grafana/runtime'
 import { getDatasourceMetadata } from './datasources'
 import { parseInputs } from './inputs'
+import { parseRequires } from './requires'
 import { convertPanels } from './panels'
 import { parseTemplating } from './templating'
 import { DsType } from './types'
@@ -41,9 +42,13 @@ export const dashboardConvert = (sourceJson: string, sourceVersion: string, targ
   // find all datasource aliases / template variables
   const datasourceMap = new Map<string,DsType>()
   const inputsArray = source['__inputs'] || []
+  const requiresArray = source['__requires'] || []
 
   const parsedInputs = parseInputs(inputsArray, datasourceMap, dsMetas)
   dashboard['__inputs'] = parsedInputs
+
+  const parsedRequires = parseRequires(requiresArray, datasourceMap, dsMetas)
+  dashboard['__requires'] = parsedRequires
 
   const templating = source['templating'] || {}
   const parsedTemplating = parseTemplating(templating, datasourceMap, dsMetas)

--- a/src/lib/dashboard-convert/performanceDs.ts
+++ b/src/lib/dashboard-convert/performanceDs.ts
@@ -26,6 +26,7 @@ export const updatePerformanceQuery = (source: any) => {
 //   "aggregation": "AVERAGE",
 //   "attribute": "loadavg5",
 //   "hide": true,
+//   "label": "label",
 //   "nodeId": "$node",
 //   "refId": "A",
 //   "resourceId": "nodeSnmp[]",
@@ -43,6 +44,7 @@ const convertAttributeQuery = (source: any): PerformanceQuery | any => {
     performanceType: PerformanceTypeOptions.Attribute,
     // PerformanceAttributeState
     attribute: {
+      label: source.label || '',
       node: {
         id: source.nodeId,
         label: source.nodeId

--- a/src/lib/dashboard-convert/requires.ts
+++ b/src/lib/dashboard-convert/requires.ts
@@ -1,0 +1,55 @@
+import { DatasourceMetadata, DsType } from './types'
+import { getDatasourceTypeFromPluginId } from './utils'
+
+// Parse the Dashboard '__requires' section, extracting any Datasource mappings and
+// updating those items to use Version 9 versions
+
+// The 'name' is the name of the variable which may be used elsewhere in queries
+// The 'pluginId' should be the datasource ID
+// We convert this to use the Version 9 versions, plus save off the variable in the map
+// to substitute elsewhere
+//
+// "__requires": [
+//   {
+//     "type": "datasource",
+//     "id": "opennms-helm-performance-datasource",
+//     "name": "OpenNMS Performance",
+//     "version": "1.0.0"
+//   }
+// ]
+export const parseRequires = (source: any[], datasourceMap: Map<string,DsType>, dsMetas: DatasourceMetadata[]) => {
+  const results: any[] = []
+
+  for (const s of source) {
+    if (s.type === 'datasource' && s.id && s.id.startsWith('opennms-')) {
+      const target = { ...s }
+      const name = s.name
+      const pluginId = s.id
+
+      if (name && pluginId) {
+        // find corresponding v9 datasource info and substitute
+        const { datasourceType } = getDatasourceTypeFromPluginId(pluginId)
+        let dsMeta = dsMetas.find(d => d.datasourceType && d.datasourceType === datasourceType && d.pluginVersion === 9)
+
+        if (!dsMeta) {
+          console.log(`Dashboard convert: did not find Version 9 datasource for '${datasourceType}', falling back to first available:`)
+          dsMeta = dsMetas.find(d => d.datasourceType && d.datasourceType === datasourceType)
+        }
+
+        if (dsMeta) {
+          target.id = dsMeta.type
+          target.name = dsMeta.name
+          target.version = dsMeta.version
+
+          results.push(target)
+          continue
+        }
+      }
+    }
+
+    // was not an OpenNms datasource, or we couldn't find a substitute, so just pass it through
+    results.push(s)
+  }
+
+  return results
+}


### PR DESCRIPTION
Fix Performance data source converter to move Attribute `label` correctly. This was causing Performance queries with Expressions to fail after conversion.

Also adds data source conversion for `__requires` section.

# External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/HELM-414
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
