### PR TITLE
HELM-422: Fix Dashboard Import for included dashboards

### DIFF
--- a/src/dashboards/cortex_flow_deep_dive.json
+++ b/src/dashboards/cortex_flow_deep_dive.json
@@ -1110,6 +1110,5 @@
   "timepicker": {},
   "timezone": "",
   "title": "Cortex Flow Deep Dive | OpenNMS Plugin for Grafana",
-  "uid": "6PhWpcZnz",
-  "version": 40
+  "version": 41
 }

--- a/src/dashboards/flow_deep_dive.json
+++ b/src/dashboards/flow_deep_dive.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 73,
+  "id": null,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -2421,6 +2421,6 @@
   },
   "timezone": "",
   "title": "Flow Deep Dive | OpenNMS Plugin for Grafana",
-  "version": 9,
+  "version": 3,
   "weekStart": ""
 }


### PR DESCRIPTION
Importing the included dashboards via "Configuration > Plugins > Dashboards" was failing.

Fix includes:

- setting dashboard `id` to null, looks like this is needed to import correctly
- removing `uid`
- `version` needs to be same or 1 more than previous value. Grafana does a check if version is mismatched, thinking it means "someone else" updated it. It could be that having a gap in version triggers this error.

# External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/HELM-422
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
