### PR TITLE
HELM-422: Convert Cortex Flow dashboard

### DIFF
--- a/src/dashboards/cortex_flow_deep_dive.json
+++ b/src/dashboards/cortex_flow_deep_dive.json
@@ -3,21 +3,30 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
         "type": "dashboard"
       }
     ]
   },
   "editable": true,
-  "gnetId": null,
+  "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1630509746057,
   "links": [],
+  "liveNow": false,
   "panels": [
     {
       "collapsed": false,
@@ -34,61 +43,122 @@
       "type": "row"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "${flowds}",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
+      "datasource": {
+        "uid": "${flowds}"
       },
-      "fill": 1,
-      "fillGradient": 0,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/\\(In/"
+            },
+            "properties": [
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "group": "A",
+                  "mode": "normal"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/\\(Out/"
+            },
+            "properties": [
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "group": "B",
+                  "mode": "normal"
+                }
+              },
+              {
+                "id": "custom.transform",
+                "value": "negative-Y"
+              }
+            ]
+          }
+        ]
+      },
       "gridPos": {
         "h": 8,
         "w": 16,
         "x": 0,
         "y": 1
       },
-      "hiddenSeries": false,
       "id": 12,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.5.7",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "alias": "/\\(In/",
-          "stack": "A"
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
         },
-        {
-          "alias": "/\\(Out/",
-          "stack": "B",
-          "transform": "negative-Y"
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
         }
-      ],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      },
+      "pluginVersion": "9.4.7",
       "targets": [
         {
+          "datasource": {
+            "uid": "${flowds}"
+          },
           "exemplar": true,
           "expr": "sum by (application) (sum_over_time(BY_TOS_AND_APP_${node}_${interface}{dscp=~\"$dscp\", direction=\"in\"}[30s])) / 30 and ignoring (direction) topk($topk, sum by (application) (sum_over_time (BY_TOS_AND_APP_${node}_${interface}{dscp=~\"$dscp\"}[$__range] @ end())))",
           "hide": false,
@@ -97,6 +167,9 @@
           "refId": "A"
         },
         {
+          "datasource": {
+            "uid": "${flowds}"
+          },
           "exemplar": true,
           "expr": "sum by (application) (sum_over_time(BY_TOS_AND_APP_${node}_${interface}{dscp=~\"$dscp\", direction=\"out\"}[30s])) / 30 and ignoring (direction) topk($topk, sum by (application) (sum_over_time (BY_TOS_AND_APP_${node}_${interface}{dscp=~\"$dscp\"}[$__range] @ end())))",
           "hide": false,
@@ -105,6 +178,9 @@
           "refId": "B"
         },
         {
+          "datasource": {
+            "uid": "${flowds}"
+          },
           "exemplar": true,
           "expr": "(sum by () (sum_over_time(EXPORTER_INTERFACE_TOS{nodeId=\"$node\", ifIndex=\"$interface\", dscp=~\"$dscp\", direction=\"in\"}[30s])) / 30) - sum by () (sum by (application) (sum_over_time(BY_TOS_AND_APP_${node}_${interface}{dscp=~\"$dscp\", direction=\"in\"}[30s])) / 30 and ignoring (direction) topk($topk, sum by (application) (sum_over_time (BY_TOS_AND_APP_${node}_${interface}{dscp=~\"$dscp\"}[$__range] @ end()))))",
           "hide": false,
@@ -113,6 +189,9 @@
           "refId": "C"
         },
         {
+          "datasource": {
+            "uid": "${flowds}"
+          },
           "exemplar": true,
           "expr": "(sum by () (sum_over_time(EXPORTER_INTERFACE_TOS{nodeId=\"$node\", ifIndex=\"$interface\", dscp=~\"$dscp\", direction=\"out\"}[30s])) / 30) - sum by () (sum by (application) (sum_over_time(BY_TOS_AND_APP_${node}_${interface}{dscp=~\"$dscp\", direction=\"out\"}[30s])) / 30 and ignoring (direction) topk($topk, sum by (application) (sum_over_time (BY_TOS_AND_APP_${node}_${interface}{dscp=~\"$dscp\"}[$__range] @ end()))))",
           "hide": false,
@@ -121,57 +200,24 @@
           "refId": "D"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Throughput by Application (TopK)",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "Bps",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "datasource": "${flowds}",
+      "datasource": {
+        "uid": "${flowds}"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "custom": {
-            "align": null,
-            "filterable": false
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
@@ -239,12 +285,23 @@
       },
       "id": 14,
       "options": {
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "7.5.7",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
+          "datasource": {
+            "uid": "${flowds}"
+          },
           "exemplar": true,
           "expr": "sort_desc(topk($topk, sum by (application) (sum_over_time (BY_TOS_AND_APP_${node}_${interface}{dscp=~\"$dscp\"}[$__range])))) or label_replace(vector(0), \"application\", \"Other\", \"none\", \".*\")",
           "format": "table",
@@ -255,6 +312,9 @@
           "refId": "A"
         },
         {
+          "datasource": {
+            "uid": "${flowds}"
+          },
           "exemplar": true,
           "expr": "sum by (application) (sum_over_time(BY_TOS_AND_APP_${node}_${interface}{dscp=~\"$dscp\", direction=\"in\"}[$__range])) and ignoring (direction) topk($topk, sum by (application) (sum_over_time (BY_TOS_AND_APP_${node}_${interface}{dscp=~\"$dscp\"}[$__range]))) or label_replace(sum by () (sum_over_time(EXPORTER_INTERFACE_TOS{nodeId=\"$node\", ifIndex=\"$interface\", dscp=~\"$dscp\", direction=\"in\"}[$__range])) - sum by () (sum by (application) (sum_over_time (BY_TOS_AND_APP_${node}_${interface}{dscp=~\"$dscp\",direction=\"in\"}[$__range])) and ignoring (direction) topk($topk, sum by (application) (sum_over_time (BY_TOS_AND_APP_${node}_${interface}{dscp=~\"$dscp\"}[$__range])))), \"application\", \"Other\", \"none\", \".*\")",
           "format": "table",
@@ -265,6 +325,9 @@
           "refId": "B"
         },
         {
+          "datasource": {
+            "uid": "${flowds}"
+          },
           "exemplar": true,
           "expr": "sum by (application) (sum_over_time(BY_TOS_AND_APP_${node}_${interface}{dscp=~\"$dscp\", direction=\"out\"}[$__range])) and ignoring (direction) topk($topk, sum by (application) (sum_over_time (BY_TOS_AND_APP_${node}_${interface}{dscp=~\"$dscp\"}[$__range]))) or label_replace(sum by () (sum_over_time(EXPORTER_INTERFACE_TOS{nodeId=\"$node\", ifIndex=\"$interface\", dscp=~\"$dscp\", direction=\"out\"}[$__range])) - sum by () (sum by (application) (sum_over_time (BY_TOS_AND_APP_${node}_${interface}{dscp=~\"$dscp\",direction=\"out\"}[$__range])) and ignoring (direction) topk($topk, sum by (application) (sum_over_time (BY_TOS_AND_APP_${node}_${interface}{dscp=~\"$dscp\"}[$__range])))), \"application\", \"Other\", \"none\", \".*\")",
           "format": "table",
@@ -275,8 +338,6 @@
           "refId": "C"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Data Usage by Application",
       "transformations": [
         {
@@ -336,61 +397,122 @@
       "id": 16,
       "panels": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "${flowds}",
-          "fieldConfig": {
-            "defaults": {},
-            "overrides": []
+          "datasource": {
+            "uid": "${flowds}"
           },
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "Bps"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/\\(In/"
+                },
+                "properties": [
+                  {
+                    "id": "custom.stacking",
+                    "value": {
+                      "group": "A",
+                      "mode": "normal"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/\\(Out/"
+                },
+                "properties": [
+                  {
+                    "id": "custom.stacking",
+                    "value": {
+                      "group": "B",
+                      "mode": "normal"
+                    }
+                  },
+                  {
+                    "id": "custom.transform",
+                    "value": "negative-Y"
+                  }
+                ]
+              }
+            ]
+          },
           "gridPos": {
             "h": 8,
             "w": 16,
             "x": 0,
             "y": 10
           },
-          "hiddenSeries": false,
           "id": 18,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "7.5.7",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "/\\(In/",
-              "stack": "A"
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
             },
-            {
-              "alias": "/\\(Out/",
-              "stack": "B",
-              "transform": "negative-Y"
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
             }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
+          },
+          "pluginVersion": "9.4.7",
           "targets": [
             {
+              "datasource": {
+                "uid": "${flowds}"
+              },
               "exemplar": true,
               "expr": "sum by (host) (sum_over_time(BY_TOS_AND_HOST_${node}_${interface}{dscp=~\"$dscp\", direction=\"in\"}[30s])) / 30 and ignoring (direction) topk($topk, sum by (host) (sum_over_time (BY_TOS_AND_HOST_${node}_${interface}{dscp=~\"$dscp\"}[$__range] @ end())))",
               "hide": false,
@@ -399,6 +521,9 @@
               "refId": "A"
             },
             {
+              "datasource": {
+                "uid": "${flowds}"
+              },
               "exemplar": true,
               "expr": "sum by (host) (sum_over_time(BY_TOS_AND_HOST_${node}_${interface}{dscp=~\"$dscp\", direction=\"out\"}[30s])) / 30 and ignoring (direction) topk($topk, sum by (host) (sum_over_time (BY_TOS_AND_HOST_${node}_${interface}{dscp=~\"$dscp\"}[$__range] @ end())))",
               "hide": false,
@@ -407,6 +532,9 @@
               "refId": "B"
             },
             {
+              "datasource": {
+                "uid": "${flowds}"
+              },
               "exemplar": true,
               "expr": "(sum by () (sum_over_time(EXPORTER_INTERFACE_TOS{nodeId=\"$node\", ifIndex=\"$interface\", dscp=~\"$dscp\", direction=\"in\"}[30s])) / 30) - sum by () (sum by (host) (sum_over_time(BY_TOS_AND_HOST_${node}_${interface}{dscp=~\"$dscp\", direction=\"in\"}[30s])) / 30 and ignoring (direction) topk($topk, sum by (host) (sum_over_time (BY_TOS_AND_HOST_${node}_${interface}{dscp=~\"$dscp\"}[$__range] @ end()))))",
               "hide": false,
@@ -415,6 +543,9 @@
               "refId": "C"
             },
             {
+              "datasource": {
+                "uid": "${flowds}"
+              },
               "exemplar": true,
               "expr": "(sum by () (sum_over_time(EXPORTER_INTERFACE_TOS{nodeId=\"$node\", ifIndex=\"$interface\", dscp=~\"$dscp\", direction=\"out\"}[30s])) / 30) - sum by () (sum by (host) (sum_over_time(BY_TOS_AND_HOST_${node}_${interface}{dscp=~\"$dscp\", direction=\"out\"}[30s])) / 30 and ignoring (direction) topk($topk, sum by (host) (sum_over_time (BY_TOS_AND_HOST_${node}_${interface}{dscp=~\"$dscp\"}[$__range] @ end()))))",
               "hide": false,
@@ -423,57 +554,24 @@
               "refId": "D"
             }
           ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
           "title": "Throughput by Host (TopK)",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "Bps",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
+          "type": "timeseries"
         },
         {
-          "datasource": "${flowds}",
+          "datasource": {
+            "uid": "${flowds}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
                 "mode": "thresholds"
               },
               "custom": {
-                "align": null,
-                "filterable": false
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
               },
               "mappings": [],
               "thresholds": {
@@ -541,12 +639,23 @@
           },
           "id": 20,
           "options": {
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
             "showHeader": true,
             "sortBy": []
           },
-          "pluginVersion": "7.5.7",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
+              "datasource": {
+                "uid": "${flowds}"
+              },
               "exemplar": true,
               "expr": "sort_desc(topk($topk, sum by (host) (sum_over_time (BY_TOS_AND_HOST_${node}_${interface}{dscp=~\"$dscp\"}[$__range]))) ) or label_replace(vector(0), \"host\", \"Other\", \"none\", \".*\")",
               "format": "table",
@@ -557,6 +666,9 @@
               "refId": "A"
             },
             {
+              "datasource": {
+                "uid": "${flowds}"
+              },
               "exemplar": true,
               "expr": "sum by (host) (sum_over_time(BY_TOS_AND_HOST_${node}_${interface}{dscp=~\"$dscp\", direction=\"in\"}[$__range])) and ignoring (direction) topk($topk, sum by (host) (sum_over_time (BY_TOS_AND_HOST_${node}_${interface}{dscp=~\"$dscp\"}[$__range]))) or label_replace(2 * sum by () (sum_over_time(EXPORTER_INTERFACE_TOS{nodeId=\"$node\", ifIndex=\"$interface\", dscp=~\"$dscp\", direction=\"in\"}[$__range])) - (sum by () (sum by (host) (sum_over_time (BY_TOS_AND_HOST_${node}_${interface}{dscp=~\"$dscp\", direction=\"in\"}[$__range])) and ignoring (direction) topk($topk, sum by (host) (sum_over_time (BY_TOS_AND_HOST_${node}_${interface}{dscp=~\"$dscp\"}[$__range]))) or vector(0))), \"host\", \"Other\", \"none\", \".*\")",
               "format": "table",
@@ -567,6 +679,9 @@
               "refId": "B"
             },
             {
+              "datasource": {
+                "uid": "${flowds}"
+              },
               "exemplar": true,
               "expr": "sum by (host) (sum_over_time(BY_TOS_AND_HOST_${node}_${interface}{dscp=~\"$dscp\", direction=\"out\"}[$__range])) and ignoring (direction) topk($topk, sum by (host) (sum_over_time (BY_TOS_AND_HOST_${node}_${interface}{dscp=~\"$dscp\"}[$__range]))) or label_replace(2 * sum by () (sum_over_time(EXPORTER_INTERFACE_TOS{nodeId=\"$node\", ifIndex=\"$interface\", dscp=~\"$dscp\", direction=\"out\"}[$__range])) - (sum by () (sum by (host) (sum_over_time (BY_TOS_AND_HOST_${node}_${interface}{dscp=~\"$dscp\", direction=\"out\"}[$__range])) and ignoring (direction) topk($topk, sum by (host) (sum_over_time (BY_TOS_AND_HOST_${node}_${interface}{dscp=~\"$dscp\"}[$__range]))) or vector(0))), \"host\", \"Other\", \"none\", \".*\")",
               "format": "table",
@@ -577,8 +692,6 @@
               "refId": "C"
             }
           ],
-          "timeFrom": null,
-          "timeShift": null,
           "title": "Data Usage by Host",
           "transformations": [
             {
@@ -642,62 +755,126 @@
       "id": 8,
       "panels": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "${flowds}",
-          "fieldConfig": {
-            "defaults": {},
-            "overrides": []
+          "datasource": {
+            "uid": "${flowds}"
           },
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "Bps"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/In/"
+                },
+                "properties": [
+                  {
+                    "id": "custom.stacking",
+                    "value": {
+                      "group": "A",
+                      "mode": "normal"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/Out/"
+                },
+                "properties": [
+                  {
+                    "id": "custom.stacking",
+                    "value": {
+                      "group": "B",
+                      "mode": "normal"
+                    }
+                  },
+                  {
+                    "id": "custom.transform",
+                    "value": "negative-Y"
+                  }
+                ]
+              }
+            ]
+          },
           "gridPos": {
             "h": 11,
             "w": 16,
             "x": 0,
             "y": 11
           },
-          "hiddenSeries": false,
           "id": 2,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": false,
-            "max": true,
-            "min": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "7.5.7",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "/In/",
-              "stack": "A"
+            "legend": {
+              "calcs": [
+                "mean",
+                "max",
+                "min"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
             },
-            {
-              "alias": "/Out/",
-              "stack": "B",
-              "transform": "negative-Y"
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
             }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
+          },
+          "pluginVersion": "9.4.7",
           "targets": [
             {
+              "datasource": {
+                "uid": "${flowds}"
+              },
               "exemplar": true,
               "expr": "sum by (dscp) (sum_over_time(EXPORTER_INTERFACE_TOS{nodeId=\"$node\", ifIndex=\"$interface\", dscp=~\"$dscp\", direction=\"in\"}[30s])) / 30",
               "interval": "",
@@ -705,6 +882,9 @@
               "refId": "A"
             },
             {
+              "datasource": {
+                "uid": "${flowds}"
+              },
               "exemplar": true,
               "expr": "sum by (dscp) (sum_over_time(EXPORTER_INTERFACE_TOS{nodeId=\"$node\", ifIndex=\"$interface\", dscp=~\"$dscp\", direction=\"out\"}[30s])) / 30",
               "hide": false,
@@ -713,57 +893,24 @@
               "refId": "B"
             }
           ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
           "title": "Throughput by DSCP",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "Bps",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
+          "type": "timeseries"
         },
         {
-          "datasource": "${flowds}",
+          "datasource": {
+            "uid": "${flowds}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
                 "mode": "thresholds"
               },
               "custom": {
-                "align": null,
-                "filterable": false
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
               },
               "mappings": [],
               "thresholds": {
@@ -843,12 +990,23 @@
           },
           "id": 6,
           "options": {
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
             "showHeader": true,
             "sortBy": []
           },
-          "pluginVersion": "7.5.7",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
+              "datasource": {
+                "uid": "${flowds}"
+              },
               "exemplar": true,
               "expr": "sort_desc(sum by (dscp) (sum_over_time(EXPORTER_INTERFACE_TOS{nodeId=\"$node\", ifIndex=\"$interface\", dscp=~\"$dscp\"}[$__range])))",
               "format": "table",
@@ -858,6 +1016,9 @@
               "refId": "A"
             },
             {
+              "datasource": {
+                "uid": "${flowds}"
+              },
               "exemplar": true,
               "expr": "sum by (dscp) (sum_over_time(EXPORTER_INTERFACE_TOS{nodeId=\"$node\", ifIndex=\"$interface\", dscp=~\"$dscp\", direction=\"in\"}[$__range]))",
               "format": "table",
@@ -868,6 +1029,9 @@
               "refId": "B"
             },
             {
+              "datasource": {
+                "uid": "${flowds}"
+              },
               "exemplar": true,
               "expr": "sum by (dscp) (sum_over_time(EXPORTER_INTERFACE_TOS{nodeId=\"$node\", ifIndex=\"$interface\", dscp=~\"$dscp\", direction=\"out\"}[$__range]))",
               "format": "table",
@@ -932,8 +1096,9 @@
       "type": "row"
     }
   ],
-  "refresh": false,
-  "schemaVersion": 27,
+  "refresh": "",
+  "revision": 1,
+  "schemaVersion": 38,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -941,11 +1106,9 @@
       {
         "current": {
           "selected": false,
-          "text": "Cortex",
-          "value": "Cortex"
+          "text": "Prometheus",
+          "value": "Prometheus"
         },
-        "description": null,
-        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "FlowDataSource",
@@ -959,16 +1122,15 @@
         "type": "datasource"
       },
       {
-        "allValue": null,
         "current": {
           "selected": false,
           "text": "2",
           "value": "2"
         },
-        "datasource": "${flowds}",
+        "datasource": {
+          "uid": "${flowds}"
+        },
         "definition": "query_result(sum by (nodeId) (min_over_time(EXPORTER_INTERFACE[$__range])))",
-        "description": null,
-        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "Node",
@@ -984,22 +1146,20 @@
         "skipUrlSync": false,
         "sort": 3,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
       },
       {
-        "allValue": null,
         "current": {
           "selected": false,
           "text": "3",
           "value": "3"
         },
-        "datasource": "${flowds}",
+        "datasource": {
+          "uid": "${flowds}"
+        },
         "definition": "query_result(sum by (ifIndex) (min_over_time(EXPORTER_INTERFACE{nodeId=\"${node}\"}[$__range])))",
-        "description": null,
-        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "Interface",
@@ -1015,13 +1175,11 @@
         "skipUrlSync": false,
         "sort": 3,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
       },
       {
-        "allValue": null,
         "current": {
           "selected": true,
           "text": [
@@ -1031,10 +1189,10 @@
             "$__all"
           ]
         },
-        "datasource": "${flowds}",
+        "datasource": {
+          "uid": "${flowds}"
+        },
         "definition": "query_result(sum by (dscp) (min_over_time(EXPORTER_INTERFACE_TOS{nodeId=\"${node}\", ifIndex=\"${interface}\"}[$__range])))",
-        "description": null,
-        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": "DSCP",
@@ -1050,20 +1208,16 @@
         "skipUrlSync": false,
         "sort": 3,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
       },
       {
-        "allValue": null,
         "current": {
           "selected": true,
           "text": "10",
           "value": "10"
         },
-        "description": null,
-        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "TopK",
@@ -1076,12 +1230,12 @@
             "value": "3"
           },
           {
-            "selected": true,
+            "selected": false,
             "text": "5",
             "value": "5"
           },
           {
-            "selected": false,
+            "selected": true,
             "text": "10",
             "value": "10"
           },
@@ -1110,5 +1264,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "Cortex Flow Deep Dive | OpenNMS Plugin for Grafana",
-  "version": 41
+  "version": 42,
+  "weekStart": ""
 }

--- a/src/lib/dashboard-convert/graphToTimeSeriesPanel.ts
+++ b/src/lib/dashboard-convert/graphToTimeSeriesPanel.ts
@@ -10,6 +10,7 @@ export const convertLegacyGraphToTimeSeriesPanel = (source: any) => {
     links: source.links,
     fieldConfig: convertFieldConfig(source),
     options: convertOptions(source),
+    pluginVersion: '9.4.7',
     type: 'timeseries'
   }
 
@@ -161,6 +162,14 @@ const convertFieldConfigOverrides = (source: any) => {
               }
             }
           ]
+        }
+
+        // e.g. 'negative-Y'
+        if (o.transform) {
+          item.properties.push({
+            id: 'custom.transform',
+            value: o.transform
+          })
         }
 
         overrides.push(item)


### PR DESCRIPTION
Convert the Cortex Flow Deep Dive dashboard to be compatible with OPG v9.

Also a small update to the dashboard convert code.

# External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/HELM-422
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
