### PR TITLE
HELM-435 Fix multi-valued template variables in Entity queries

### DIFF
--- a/src/datasources/entity-ds/EntityClause.tsx
+++ b/src/datasources/entity-ds/EntityClause.tsx
@@ -88,6 +88,14 @@ export const EntityClause = ({
     }
 
     return (
+        <>
+        <style>
+          {`
+            label.entity-attr-value-segment, label.entity-attr-value-segment-input {
+              min-width: 100px;
+            }
+          `}
+        </style>
         <InlineFieldRow>
             <EntityClauseLabel
                 type={clause.type}
@@ -127,6 +135,7 @@ export const EntityClause = ({
             />
             {clause.attribute?.value?.values && Object.keys(clause.attribute?.value.values).length > 0 ?
                 <Segment
+                    className='entity-attr-value-segment'
                     allowEmptyValue={false}
                     value={clause.comparedValue}
                     onChange={(text) => {
@@ -135,6 +144,7 @@ export const EntityClause = ({
                     options={comparedOptions}
                 /> :
                 <SegmentInput
+                    className='entity-attr-value-segment-input'
                     placeholder='select value'
                     type={getInputTypeFromAttributeType(clause.attribute)}
                     onChange={(text) => {
@@ -157,5 +167,6 @@ export const EntityClause = ({
             </>
             }
         </InlineFieldRow>
+      </>
     )
 }

--- a/src/datasources/entity-ds/EntityClauseEditor.tsx
+++ b/src/datasources/entity-ds/EntityClauseEditor.tsx
@@ -37,6 +37,7 @@ export const EntityClauseEditor = ({ setFilter, loading, propertiesAsArray, clau
                 )
             }
         })
+        
         setFilter(updatedFilter);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [clauses])

--- a/src/datasources/flow-ds/helpers.ts
+++ b/src/datasources/flow-ds/helpers.ts
@@ -1034,7 +1034,8 @@ const metricFindInterfacesOnExporterNode = async ({ client, simpleRequest }, ser
 }
 
 const metricFindDscpOnExporterNodeAndInterface = async ({ client, simpleRequest }, service: FlowTemplateVariableQueryService) => {
-    let dscpValues = await client.getDscpValues(service.nodeCriteria, service.iface, service.start, service.end);
+    let dscpValues = await client.getDscpValues(service.nodeCriteria, service.iface?.trim() || '', service.start, service.end);
+
     return dscpSelectOptions(dscpValues);
 }
 


### PR DESCRIPTION
Multi-valued template variables were not being processed correctly resulting in them not working and sending out incorrect FIQL, for example when used in the Alarm Table panel.

Looks like Grafana 9 uses `multi` instead of `isMulti` for multi-valued template variables, so we were not catching them and converting into nested restrictions. Also if a multi-valued variable was found, it was skipping processing subsequent clauses, like the date range clause.

Also:

- added some `min-width` for Entity query clause variable values so it's easier to enter a template variable
- fixed a small issue in Flows query


# External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/HELM-435
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
