### PR TITLE
HELM-443: Fix antora content source to fix documentation build

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -5,8 +5,7 @@ site:
 content:
   sources:
   - url: https://github.com/OpenNMS/grafana-plugin
-    branches: HEAD
-    tags: v*
+    branches: release-9.x
     start_path: docs
 ui:
   bundle:
@@ -23,6 +22,6 @@ asciidoc:
 output:
   clean: true
   dir: ./public
-  destinations
+  destinations:
   - provider: fs
   - provider: archive


### PR DESCRIPTION
Fixes a couple issues preventing the Antora site documentation from building.

There was a syntax error (missing colon after `destinations`) and also need to use `release-9.x` branch as the content source instead of `tag: v*`. Antora saw `v*` tag and tried to get files from GitHub repo tag v4.0.1.

# External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/HELM-443
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
