### PR TITLE
HELM-440: Fix date and multi-value handling in Entity clauses and queries

### DIFF
--- a/src/datasources/entity-ds/EntityClause.tsx
+++ b/src/datasources/entity-ds/EntityClause.tsx
@@ -91,7 +91,7 @@ export const EntityClause = ({
         <>
         <style>
           {`
-            label.entity-attr-value-segment, label.entity-attr-value-segment-input {
+            .entity-attr-value label.entity-attr-value-segment, label.entity-attr-value-segment-input, input.gf-form-input {
               min-width: 100px;
             }
           `}
@@ -133,6 +133,7 @@ export const EntityClause = ({
                 }}
                 options={comparatorOptions}
             />
+            <div className='entity-attr-value'>
             {clause.attribute?.value?.values && Object.keys(clause.attribute?.value.values).length > 0 ?
                 <Segment
                     className='entity-attr-value-segment'
@@ -163,6 +164,7 @@ export const EntityClause = ({
                     value={clause.comparedString}
                 />
             }
+            </div>
             {loading && <div style={{ display: 'flex', alignItems: 'center' }}>
                 <Spinner />
             </div>

--- a/src/datasources/entity-ds/EntityClause.tsx
+++ b/src/datasources/entity-ds/EntityClause.tsx
@@ -1,8 +1,8 @@
-import { SelectableValue } from '@grafana/data';
-import { Segment, SegmentInput, Spinner, Button, InlineFieldRow } from '@grafana/ui';
+import { SelectableValue } from '@grafana/data'
+import { Segment, SegmentInput, Spinner, Button, InlineFieldRow } from '@grafana/ui'
 import React, { useEffect, useState } from 'react'
-import { EntityClauseLabel } from './EntityClauseLabel';
-import { Comparator, EntityClauseProps, OnmsEntityType, OnmsEntityNestType, SearchOption, ClauseActionType } from './types';
+import { EntityClauseLabel } from './EntityClauseLabel'
+import { Comparator, EntityClauseProps, OnmsEntityType, OnmsEntityNestType, SearchOption, ClauseActionType } from './types'
 import { API } from 'opennms'
 
 export const EntityClause = ({
@@ -67,7 +67,7 @@ export const EntityClause = ({
     const getInputTypeFromAttributeType = (attribute: SearchOption | undefined) => {
         let type = 'text';
         if (attribute?.value?.type?.i === 'TIMESTAMP') {
-            type = 'date'
+            type = 'datetime-local'
         } else if (attribute?.value?.type?.i === 'INTEGER') {
             type = 'number'
         }
@@ -138,8 +138,10 @@ export const EntityClause = ({
                     className='entity-attr-value-segment'
                     allowEmptyValue={false}
                     value={clause.comparedValue}
-                    onChange={(text) => {
-                        setComparedValue(index, text);
+                    onChange={(value) => {
+                        // clear any existing string value, set new SelectableValue
+                        setComparedString(index, '')
+                        setComparedValue(index, value)
                     }}
                     options={comparedOptions}
                 /> :
@@ -147,8 +149,16 @@ export const EntityClause = ({
                     className='entity-attr-value-segment-input'
                     placeholder='select value'
                     type={getInputTypeFromAttributeType(clause.attribute)}
-                    onChange={(text) => {
-                        setComparedString(index, text);
+                    onChange={(value) => {
+                        const inputType = getInputTypeFromAttributeType(clause.attribute)
+
+                        // clear any existing SelectableValue, set new string value
+                        // if this value is a date / timestamp, convert to ISO string so that
+                        // queries are sent correctly
+                        setComparedValue(index, {})
+
+                        const inputValue = (value && inputType.startsWith('date')) ? new Date(value).toISOString() : value
+                        setComparedString(index, inputValue || '')
                     }}
                     value={clause.comparedString}
                 />

--- a/src/datasources/entity-ds/EntityDataSource.ts
+++ b/src/datasources/entity-ds/EntityDataSource.ts
@@ -67,6 +67,7 @@ export class EntityDataSource extends DataSourceApi<EntityQuery> {
             request.entityType = target?.selectType?.label || EntityTypes.Alarms
             // possibly should be an option in the panel editor
             request.enforceTimeRange = true
+
             const filter = buildQueryFilter(target?.filter || new API.Filter(), request, this.templateSrv)
 
             if (hasFilterEditorData) {

--- a/src/lib/dashboard-convert/entityDs.ts
+++ b/src/lib/dashboard-convert/entityDs.ts
@@ -76,8 +76,8 @@ export const updateEntityQuery = (source: any) => {
         value: c.restriction.comparator.id
       },
       comparedString: c.restriction.value,
-      // TODO: Not sure what this should be
-      comparedValue: "",
+      // Clearing this, using comparedString only for now
+      comparedValue: '',
       // TODO: figure out nestingType
       nestingType: OnmsEntityNestType.TOP,
       type: entityType


### PR DESCRIPTION
Fixed some issues with Entity data source date and multi-value handling, which were causing behavior in the bug ticket.

- use either `comparedString` or `comparedValue` in query clauses, but not both. This was causing some mixups with how queries were sent to the Rest API

- using `datetime-local` input type for dates, allows user to set the full date and time and uses ISO date format when sending to Rest API

- remove any empty query clauses before sending to `opennms-js` and doing the Rest query. This could happen when a mult-value template variable is used but all options are deselected, and was causing an invalid query to be sent. Behavior now is as if the filter was not applied at all

- also fixes HELM-442 issue entering manual text (like a template variable) in an Entity DS `where` clause

# External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/HELM-440
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
