### PR TITLE
HELM-430: Performance datasource, allow brace and brace:fmt variable syntax

### DIFF
--- a/src/datasources/perf-ds/PerformanceHelpers.ts
+++ b/src/datasources/perf-ds/PerformanceHelpers.ts
@@ -102,9 +102,9 @@ const measurementColumnToDataFrame = (
   if (column) {
     // Only use values within the timestamp window
     // Replace any literal 'NaN' values with null
-    let windowedValues = column.values.slice(startIndex, endIndex + 1).map(v => v === 'NaN' ? null : v)
+    const windowedValues = column.values.slice(startIndex, endIndex + 1).map(v => v === 'NaN' ? null : v)
 
-    let field = {
+    const field = {
       name: formattedLabel || 'Value',
       type: FieldType.number, // will be a number, a string representing a number or else null
       config: {},

--- a/src/datasources/perf-ds/queries/interpolate.ts
+++ b/src/datasources/perf-ds/queries/interpolate.ts
@@ -31,7 +31,7 @@ interface TemplateSrvVariable {
  *
  * Note, in latest Grafana, templateSrv.getVariables() items are VariableWithOptions
  * We don't use all the properties of these, and they may not be present in earlier Grafana versions,
- * so we use the above interface definitions to provide some typing information.
+ * so we use the above interface definitions (e.g. InterpolationVariable) to provide some typing information.
  * See: https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/types/templateVars.ts
  */
 export const collectInterpolationVariables = (templateSrv: TemplateSrv, scopedVars?: ScopedVars): InterpolationVariable[] => {
@@ -48,9 +48,9 @@ export const collectInterpolationVariables = (templateSrv: TemplateSrv, scopedVa
         if (scopedVars && scopedVars[variable.name] !== undefined && scopedVars[variable.name] !== null) {
             variable.value = [scopedVars[variable.name]?.value?.toString()];
         } else {
-            // TODO: templateSrv.getVariables() in Grafana 8.5 returns VariableModel[],
+            // Note: templateSrv.getVariables() in Grafana 8.5 returns VariableModel[],
             // VariableModel does NOT contain 'current' or 'current.value'
-            // But latest Grafana, 9.4.0, returns TypedVariableModel[], which is actually
+            // But recent Grafana, 9.4.0+, returns TypedVariableModel[], which is actually
             // instances of DashboardVariableModel, which is SystemVariable<DashboardProps> which
             // DOES contain 'current' and 'current.value'
             const templateSrvVariable = (templateVariable as any) as TemplateSrvVariable
@@ -80,28 +80,81 @@ export const collectInterpolationVariables = (templateSrv: TemplateSrv, scopedVa
     return variables
 }
 
-const defaultContainsVariable = (value: any | undefined, variableName: string) => {
-    if (value === null || value === undefined || !isString(value)) {
+/**
+ * Returns whether the given value possibly contains a variable reference.
+ */
+const isVariableReferenceCandidate = (value: any): boolean => {
+  return value !== undefined && value !== null && value !== '' &&
+    isString(value) && (value as string).includes('$')
+}
+
+/**
+ * Get a regex pattern for the given variable name which includes braces and an optional format.
+ */
+const getVariableWithBracesReferencePattern = (name: string) => {
+  return '\\${' + name + '(?::[a-zA-Z0-9]+)?}'
+}
+
+/**
+ * Checks whether a query (e.g. Performance Attribute query string) contains a template variable reference
+ * such as $var, ${var}, ${var:fmt}.
+ * @param queryValue Value of the query string
+ * @param variableName Value of the template variable, without any decoration
+ * @returns boolean. Could (in future) return an object such as { found: boolean, format?: string } if we want to know whether
+ *   we need to check the brace format during variable interpolation replacement.
+ */
+const containsVariableReference = (queryValue: any, variableName: string) => {
+    if (!isVariableReferenceCandidate(queryValue)) {
         return false
     }
 
-    return (value as string).indexOf('$' + variableName) >= 0
-}
+    const strValue = queryValue as string || ''
 
-const defaultReplace = (value: any, variables: InterpolationVariable[]) => {
-    if (value === null || value === undefined || value === '') {
-        return value;
+    if (strValue.indexOf('$' + variableName) >= 0) {
+      return true
     }
 
-    let interpolatedValue = value;
+    if (strValue.includes('${' + variableName)) {
+      const pattern = getVariableWithBracesReferencePattern(variableName)
+      const r = new RegExp(pattern)
+
+      return r.test(strValue)
+    }
+
+    return false
+}
+
+/**
+ * Replaces any and all variable references in a query with their interpolated values.
+ */
+const replaceQueryValueWithVariables = (queryValue: any, variables: InterpolationVariable[]) => {
+    // simple check so we don't bother to run regexes on values that definitely do not
+    // contain interpolated variable references
+    if (!isVariableReferenceCandidate(queryValue)) {
+      return queryValue
+    }
+
+    let interpolatedValue: string = queryValue as string
 
     variables.forEach(variable => {
-        const regexVarName = "\\$" + variable.name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        // Note: variable.value should be a string at this point, not an array, since it
+        // already went through cartesianProductOfVariables()
+        // Just making sure here :)
+        let variableValue: string = variable.value as string ?? ''
+        if (Array.isArray(variable.value) && variable.value.length > 0) {
+          variableValue = variable.value[0]
+        }
 
-        interpolatedValue = interpolatedValue.replace(new RegExp(regexVarName, 'g'), variable.value);
+        // check for '$variableName' syntax
+        const regexVarName = '\\$' + variable.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+        interpolatedValue = interpolatedValue.replace(new RegExp(regexVarName, 'g'), variableValue)
+
+        // check for ${var} with optional {$var:format} where 'format' must be alphanumeric
+        const regexWithBracesAndFormat = getVariableWithBracesReferencePattern(variable.name)
+        interpolatedValue = interpolatedValue.replace(new RegExp(regexWithBracesAndFormat, 'g'), variableValue)
     })
 
-    return interpolatedValue;
+    return interpolatedValue
 }
 
 const cartesianProductOfArrays = <T>(arrays: T[][]): T[][] => {
@@ -127,6 +180,26 @@ const cartesianProductOfArrays = <T>(arrays: T[][]): T[][] => {
     return r;
 }
 
+/**
+ * Takes variables in the form:
+ * [
+ *   { name: 'node', value: ['1', '6'] },       // index == 0
+ *   { name: 'ifIndex', value: ['8', '9'] } .   // index == 1
+ * ]
+ * and converts them to the form:
+ * [
+ *   [                                          // index == 0
+ *     { name: 'node', value: '1' },
+ *     { name: 'node', value: '6' }
+ *   ],
+ *   [                                          // index == 1
+ *     { name: 'ifIndex', value: '8' },
+ *     { name: 'ifIndex', value: '9' }
+ *   ]
+ * ]
+ * 
+ * Note that the array index of the outer array points to the values for the same variable name
+ */
 const cartesianProductOfVariables = (variables: InterpolationVariable[]) => {
     // Collect the values from all of the variables
     const allValues: string[][] = variables.map(v => Array.isArray(v.value) ? v.value : [v.value])
@@ -141,7 +214,7 @@ const cartesianProductOfVariables = (variables: InterpolationVariable[]) => {
         const rowOfVariables = [] as InterpolationVariable[]
 
         for (let i = 0, l = variables.length; i < l; i++) {
-            const variable = cloneDeep(variables[i])
+            const variable: InterpolationVariable = cloneDeep(variables[i])
             variable.value = rowOfValues[i]
             rowOfVariables.push(variable)
         }
@@ -158,28 +231,26 @@ const cartesianProductOfVariables = (variables: InterpolationVariable[]) => {
  * If a referenced variable contains multiple values or if there are multiple referenced variables
  * then we generate copies of the source with all of the possible permutations.
  *
- * See interpolate_spec.js for examples.
+ * See perf_ds_interpolate_spec.ts for examples.
  *
  * T is actually going to be:
  * - OnmsMeasurementsQuerySource for Attribute queries
  * - OnmsMeasurementsQueryExpression for Expression queries
  * - PerformanceQuery.filterState (just an object) for Filter queries
- *
+ * 
  * @param object
- *    the object to interpolate
+ *    the query object of type T to interpolate, see above
  * @param attributes
- *    a list of attributes on a given object that should be checked for variables
- * @param variables
- *    a list of variables of the form [{name: 'varname', value: ['value1', 'value2']}, ...]
+ *    a list of attributes on a given object that should be checked for variable interpolation.
+ * @param interpolationVars
+ *    a list of variable names and values from Grafana templateSrv of the form [{ name: 'varname', value: ['value1', 'value2'] }, ...]
  * @param callback
  *    an optional callback made with the object after variable substitution has been performed
- * @param containsVariable
- *    optionally override the function used to determine if a string contains a reference to the named variable
- * @param replace
- *    optionally override the function used to substitute the variable reference in a string with the variables's value
- * @returns an array of objects, if no substitutions were performed, the array will contain the original object
+ * @returns an array of objects of type T (see above) containing variable substitutions;
+ *    if no substitutions were performed, the array will contain the original object
  */
-export const interpolate = <T extends any>(object: T, attributes: string[],
+export const interpolate = <T>(object: T,
+    attributes: string[],
     interpolationVars: InterpolationVariable[],
     callback: (src: T) => void = () => {}): T[] => {
 
@@ -190,8 +261,12 @@ export const interpolate = <T extends any>(object: T, attributes: string[],
     // Collect the list of variables that are referenced by one or more of the keys
     const referencedVariables = [] as InterpolationVariable[]
 
+    // Note: we could keep track of what variables are referenced by which attribute queries,
+    // and also whether variables may have been referenced using ${var} or ${var:fmt} format
+    // to not perform as many regexes, but keeping it simpler for now
+
     variablesWithIndex.forEach(variable => {
-        const isVariableReferenced = attributes.find(attribute => defaultContainsVariable(object[attribute], variable.name))
+        const isVariableReferenced = attributes.find(attribute => containsVariableReference(object[attribute], variable.name))
 
         if (isVariableReferenced) {
             referencedVariables.push(variable)
@@ -223,7 +298,7 @@ export const interpolate = <T extends any>(object: T, attributes: string[],
         const o = { ...(object as any) }
 
         attributes.forEach(attribute => {
-            o[attribute] = defaultReplace(o[attribute], rowOfReferencedVariables)
+            o[attribute] = replaceQueryValueWithVariables(o[attribute], rowOfReferencedVariables)
         })
 
         callback(o)

--- a/src/test/react/lib_utils.spec.ts
+++ b/src/test/react/lib_utils.spec.ts
@@ -18,6 +18,5 @@ describe('Utils :: processSelectionVariables', () => {
 
     array = processSelectionVariables(['["Default",0,"0.0.0.0","0.0.0.0","app1"],["Default",0,"0.0.0.0","0.0.0.0","app2"],["Default",0,"0.0.0.0","0.0.0.1","app3"],["Default",0,"0.0.0.0","0.0.0.0","app4"]']);
     expect(array.length).toEqual(4);
-
   });
 });

--- a/src/test/react/perf_ds_interpolate.spec.ts
+++ b/src/test/react/perf_ds_interpolate.spec.ts
@@ -1,83 +1,107 @@
-import { interpolate } from '../../datasources/perf-ds/queries/interpolate';
+import { interpolate } from '../../datasources/perf-ds/queries/interpolate'
 
-describe('OpenNMSPMDatasource :: interpolate', function () {
-  let query = {'resource': '$node', 'metric': '$x.$y'};
+describe('OpenNMSPerformanceDatasource :: interpolate', () => {
+  const query = { resource: '$node', metric: '$x.$y' }
+  const queryWithBraces = { resource: '${node}', metric: '$x.$y' }
+  const queryWithBracesAndFormat = { resource: '${node:csv}', metric: '$x.$y' }
 
-  it('should return the same object when the list of attributes is empty', function () {
-    expect(interpolate(query, [], [])).toStrictEqual([query]);
-  });
+  it('should return the same object when the list of attributes is empty', () => {
+    expect(interpolate(query, [], [])).toStrictEqual([query])
+  })
 
-  it('should return the same object when the list of variables is empty', function () {
-    expect(interpolate(query, ['resource'], [])).toStrictEqual([query]);
-  });
+  it('should return the same object when the list of variables is empty', () => {
+    expect(interpolate(query, ['resource'], [])).toStrictEqual([query])
+  })
 
-  it('should return the same object when no matching variables are referenced', function () {
-    expect(interpolate(query, ['resource'], [{name: '!node', value: ['1']}])).toStrictEqual([query]);
-  });
+  it('should return the same object when no matching variables are referenced', () => {
+    expect(interpolate(query, ['resource'], [{ name: '!node', value: ['1'] }])).toStrictEqual([query])
+  })
 
-  it('should be able to interpolate a single variable in a single attribute', function () {
-    let interpolated = interpolate(query, ['resource'], [{name: 'node', value: ['1', '2']}]);
-    expect(interpolated).toStrictEqual([
-      {'resource': '1', 'metric': '$x.$y'},
-      {'resource': '2', 'metric': '$x.$y'}
-    ]);
-  });
-
-  it('should be able to interpolate multiple variables in a single attribute', function () {
-    let interpolated = interpolate(query, ['metric'], [
-      {name: 'x', value: ['x1', 'x2']},
-      {name: 'y', value: ['y1', 'y2']}
-    ]);
-    expect(interpolated).toStrictEqual([
-      {'resource': '$node', 'metric': 'x1.y1'},
-      {'resource': '$node', 'metric': 'x1.y2'},
-      {'resource': '$node', 'metric': 'x2.y1'},
-      {'resource': '$node', 'metric': 'x2.y2'}
-    ]);
-  });
-
-  it('should be able to interpolate multiple variables in multiple attributes', function () {
-    let interpolated = interpolate(query, ['resource', 'metric'], [
-      {name: 'node', value: ['1', '2']},
-      {name: 'x', value: ['x1', 'x2']},
-      {name: 'y', value: ['y1', 'y2']}
-    ]);
-    expect(interpolated).toStrictEqual([
-      {'resource': '1', 'metric': 'x1.y1'},
-      {'resource': '1', 'metric': 'x1.y2'},
-      {'resource': '1', 'metric': 'x2.y1'},
-      {'resource': '1', 'metric': 'x2.y2'},
-      {'resource': '2', 'metric': 'x1.y1'},
-      {'resource': '2', 'metric': 'x1.y2'},
-      {'resource': '2', 'metric': 'x2.y1'},
-      {'resource': '2', 'metric': 'x2.y2'}
-    ]);
-  });
-
-  it('should support interpolating a special variable named $index which is unique for every row', function () {
-    let queryWithIndex = {'resource': 'node', 'metric': '$x.$y', 'label': '$index'};
-
-    let interpolated = interpolate(queryWithIndex, ['resource', 'metric', 'label'], [
-      {name: 'x', value: ['x1', 'x2']},
-      {name: 'y', value: ['y1', 'y2']}
-    ]);
+  it('should be able to interpolate a single variable in a single attribute', () => {
+    const interpolated = interpolate(query, ['resource'], [{ name: 'node', value: ['1', '2'] }])
 
     expect(interpolated).toStrictEqual([
-      {'resource': 'node', 'metric': 'x1.y1', 'label': 'idx0'},
-      {'resource': 'node', 'metric': 'x1.y2', 'label': 'idx1'},
-      {'resource': 'node', 'metric': 'x2.y1', 'label': 'idx2'},
-      {'resource': 'node', 'metric': 'x2.y2', 'label': 'idx3'}
-    ]);
-  });
+      { resource: '1', metric: '$x.$y' },
+      { resource: '2', metric: '$x.$y' }
+    ])
+  })
 
-  it('should be able to interpolate multiple variables with the same name in a single attribute', function () {
-    let queryWithMultipleVariables = {'resource': '$node', 'metric': '$x-var + $x-var'};
-    let interpolated = interpolate(queryWithMultipleVariables, ['resource', 'metric'], [
-      {name: 'x-var', value: ['x1', 'x2']},
-    ]);
+  it('should be able to interpolate multiple variables in a single attribute', () => {
+    const interpolated = interpolate(query, ['metric'], [
+      { name: 'x', value: ['x1', 'x2'] },
+      { name: 'y', value: ['y1', 'y2'] }
+    ])
+
     expect(interpolated).toStrictEqual([
-      {'resource': '$node', 'metric': 'x1 + x1'},
-      {'resource': '$node', 'metric': 'x2 + x2'}
-    ]);
-  });
-});
+      { resource: '$node', metric: 'x1.y1' },
+      { resource: '$node', metric: 'x1.y2' },
+      { resource: '$node', metric: 'x2.y1' },
+      { resource: '$node', metric: 'x2.y2' }
+    ])
+  })
+
+  it('should be able to interpolate multiple variables in multiple attributes', () => {
+    const interpolated = interpolate(query, ['resource', 'metric'], [
+      { name: 'node', value: ['1', '2'] },
+      { name: 'x', value: ['x1', 'x2'] },
+      { name: 'y', value: ['y1', 'y2'] }
+    ])
+
+    expect(interpolated).toStrictEqual([
+      { resource: '1', metric: 'x1.y1' },
+      { resource: '1', metric: 'x1.y2' },
+      { resource: '1', metric: 'x2.y1' },
+      { resource: '1', metric: 'x2.y2' },
+      { resource: '2', metric: 'x1.y1' },
+      { resource: '2', metric: 'x1.y2' },
+      { resource: '2', metric: 'x2.y1' },
+      { resource: '2', metric: 'x2.y2' }
+    ])
+  })
+
+  it('should support interpolating a special variable named $index which is unique for every row', () => {
+    const queryWithIndex = {'resource': 'node', 'metric': '$x.$y', 'label': '$index'}
+
+    const interpolated = interpolate(queryWithIndex, ['resource', 'metric', 'label'], [
+      { name: 'x', value: ['x1', 'x2'] },
+      { name: 'y', value: ['y1', 'y2'] }
+    ])
+
+    expect(interpolated).toStrictEqual([
+      { resource: 'node', metric: 'x1.y1', label: 'idx0' },
+      { resource: 'node', metric: 'x1.y2', label: 'idx1' },
+      { resource: 'node', metric: 'x2.y1', label: 'idx2' },
+      { resource: 'node', metric: 'x2.y2', label: 'idx3' }
+    ])
+  })
+
+  it('should be able to interpolate multiple variables with the same name in a single attribute', () => {
+    const queryWithMultipleVariables = {'resource': '$node', 'metric': '$x-var + $x-var'}
+    const interpolated = interpolate(queryWithMultipleVariables, ['resource', 'metric'], [
+      { name: 'x-var', value: ['x1', 'x2'] }
+    ])
+
+    expect(interpolated).toStrictEqual([
+      { resource: '$node', metric: 'x1 + x1' },
+      { resource: '$node', metric: 'x2 + x2' }
+    ])
+  })
+
+  it('should be able to interpolate a single variable-with-braces in a single attribute', () => {
+    const interpolated = interpolate(queryWithBraces, ['resource'], [{ name: 'node', value: ['1', '2'] }])
+
+    expect(interpolated).toStrictEqual([
+      { resource: '1', metric: '$x.$y' },
+      { resource: '2', metric: '$x.$y' }
+    ])
+  })
+
+  it('should be able to interpolate a single variable-with-braces-and-format in a single attribute', () => {
+    const interpolated = interpolate(queryWithBracesAndFormat, ['resource'], [{ name: 'node', value: ['1', '2'] }])
+
+    expect(interpolated).toStrictEqual([
+      { resource: '1', metric: '$x.$y' },
+      { resource: '2', metric: '$x.$y' }
+    ])
+  })
+})


### PR DESCRIPTION
Allow `$var`, `${var}` and `${var:fmt}` syntax in template variable references in Performance data source queries.

Note that we don't do any special format processing when a format is specified.

Also did some refactoring of the interpolation code.

# External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/HELM-430
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
