### PR TITLE
HELM-439: Filter Panel horizontal layout option

### DIFF
--- a/src/datasources/entity-ds/types.ts
+++ b/src/datasources/entity-ds/types.ts
@@ -4,11 +4,12 @@ import {
   DataQuery,
   DataQueryRequest,
   DataSourceJsonData,
+  MetricFindValue,
   SelectableValue,
   QueryEditorProps,
   TableData
-} from '@grafana/data';
-import { EntityDataSource } from './EntityDataSource';
+} from '@grafana/data'
+import { EntityDataSource } from './EntityDataSource'
 import { GrafanaDatasource } from '../../hooks/useDataSources'
 
 /**
@@ -149,6 +150,12 @@ export interface OnmsColumn extends Column {
   visible?: boolean
 }
 
+// Values actually returned by OpenNMS metricFindQuery
+export interface OnmsMetricFindValue extends MetricFindValue {
+  id?: string
+  label?: string
+}
+
 export interface OnmsTableData extends TableData {
   // override
   columns: OnmsColumn[]
@@ -181,6 +188,7 @@ export interface FilterSelectableValues {
  */
 export interface FilterEditorData {
   dashboardUid: string
+  isHorizontalLayout: boolean
   datasource: SelectableValue<GrafanaDatasource> | undefined
   activeFilters: ActiveFilter[]
   selectableValues: FilterSelectableValues[]

--- a/src/panels/filter-panel/FilterPanelControlField.tsx
+++ b/src/panels/filter-panel/FilterPanelControlField.tsx
@@ -1,0 +1,109 @@
+import React from 'react'
+import { SelectableValue } from '@grafana/data'
+import { HorizontalGroup, Input, Select } from '@grafana/ui'
+import { FieldDisplay } from 'components/FieldDisplay'
+import { ALL_SELECTION_VALUE } from 'constants/constants'
+import { ActiveFilter, FilterSelectableValues, OnmsMetricFindValue } from '../../datasources/entity-ds/types'
+
+interface FilterPanelControlFieldProps {
+  filter: ActiveFilter
+  getFilterId: (filter: ActiveFilter) => string
+  index: number
+  inputChanged: (e: any, filter: ActiveFilter) => void
+  isHorizontal?: boolean
+  metricValues: Array<[string, OnmsMetricFindValue[]]>
+  selectableValues: FilterSelectableValues[]
+  selectChanged: (value: (SelectableValue | SelectableValue[]), filter: ActiveFilter) => void
+}
+
+export const FilterPanelControlField: React.FC<FilterPanelControlFieldProps> = (props) => {
+    const filterDisplayLabel = (filter: ActiveFilter, index: number) => {
+        const altLabel = filter.altColumnLabel
+
+        if (altLabel) {
+            return altLabel
+        }
+
+        return `${filter.entity.label || ''}: ${filter.attribute.label || ''}`
+    }
+
+    const getInputSelectableValue = (filter: ActiveFilter) => {
+        const filterId = props.getFilterId(filter)
+        const selVals = props.selectableValues.find(v => v.filterId === filterId)
+
+        if (selVals && selVals.values?.length > 0) {
+            return selVals.values[0].value || ''
+        }
+
+        return ''
+    }
+
+    const getSelectSelectableValues = (filter: ActiveFilter) => {
+        const filterId = props.getFilterId(filter)
+        const selVals = props.selectableValues.find(v => v.filterId === filterId)
+
+        return selVals?.values || []
+    }
+
+    const generateFilterSelectOptions = (filter: ActiveFilter) => {
+        const filterId = props.getFilterId(filter)
+        const isMulti = filter.selectionType?.label === 'Multi'
+        const [key, currentValues] = props.metricValues.find(([k,v]) => k === filterId) || []
+
+        if (key && currentValues) {
+            const values = currentValues.map(v => ({
+                label: v.text,
+                value: v.value || ''
+            } as SelectableValue<string | number>))
+
+            // Single select dropdown add 'All'
+            // For multi-select, user would just not select anything
+            if (!isMulti) {
+                const allValue = { label: 'All', value: ALL_SELECTION_VALUE}
+                return [allValue, ...values]
+            }
+
+            return values
+        }
+
+        return []
+    }
+
+    return (
+      <>
+        <style>
+        {
+          `
+          .filter-panel-horizontal-layout div[class$='horizontal-group'] {
+            align-items: baseline;
+          }
+
+          .filter-panel-field {
+            min-width: 100px;
+          }
+          `
+        }
+        </style>
+
+        <div className={ props.isHorizontal ? 'filter-panel-horizontal-layout' : '' }>
+          <HorizontalGroup key={props.getFilterId(props.filter)}>
+              <FieldDisplay>{filterDisplayLabel(props.filter, props.index)}</FieldDisplay>
+              { props.filter.selectionType?.label === 'Text' ?
+                <Input
+                  value={getInputSelectableValue(props.filter)}
+                  onChange={(e) => props.inputChanged(e, props.filter)}
+                />
+                :
+                <Select
+                  className='filter-panel-field'
+                  isMulti={props.filter.selectionType?.label === 'Multi'}
+                  options={generateFilterSelectOptions(props.filter)}
+                  value={getSelectSelectableValues(props.filter)}
+                  menuShouldPortal={true}
+                  onChange={(value) => props.selectChanged(value, props.filter)} />
+              }
+          </HorizontalGroup>
+        </div>
+    </>
+  )
+}

--- a/src/panels/filter-panel/FilterPanelLayoutOptions.tsx
+++ b/src/panels/filter-panel/FilterPanelLayoutOptions.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { Switch } from '@grafana/ui'
+import { OnmsInlineField } from 'components/OnmsInlineField'
+import { SwitchBox } from 'components/SwitchBox'
+
+interface FilterPanelLayoutOptionsProps {
+    isHorizontal?: boolean
+    onChange: Function
+}
+
+export const FilterPanelLayoutOptions: React.FC<FilterPanelLayoutOptionsProps> = ({ isHorizontal, onChange }) => {
+    return (
+      <OnmsInlineField label='Use horizontal layout'>
+        <SwitchBox>
+          <Switch
+            value={isHorizontal}
+            onChange={(e) => onChange(!isHorizontal)} />
+        </SwitchBox>
+      </OnmsInlineField>
+    )
+}

--- a/src/panels/filter-panel/FilterPanelOptions.tsx
+++ b/src/panels/filter-panel/FilterPanelOptions.tsx
@@ -4,6 +4,7 @@ import { GrafanaDatasource } from 'hooks/useDataSources'
 import { useOpenNMSClient } from '../../hooks/useOpenNMSClient'
 import { ActiveFilter } from '../../datasources/entity-ds/types'
 import { FilterPanelDataSource } from './FilterPanelDataSource'
+import { FilterPanelLayoutOptions } from './FilterPanelLayoutOptions'
 import { FilterPanelFilterSelector } from './FilterPanelFilterSelector'
 import { FilterPanelActiveFilters } from './FilterPanelActiveFilters'
 import { loadFilterEditorData } from 'lib/localStorageService'
@@ -12,13 +13,15 @@ import { ClearFilterData } from '../../components/ClearFilterData'
 interface FilterPanelOptionOptions {
     datasource: SelectableValue<GrafanaDatasource>
     activeFilters: ActiveFilter[]
+    isHorizontalLayout: boolean
 }
 
 export const FilterPanelOptions: React.FC<PanelOptionsEditorProps<FilterPanelOptionOptions>> = (props) => {
     const [internalOptions, setInternalOptions] = useState<FilterPanelOptionOptions>(
         {
             datasource: props.context.options?.datasource || {},
-            activeFilters: props.context.options?.activeFilters || []
+            activeFilters: props.context.options?.activeFilters || [],
+            isHorizontalLayout: props.context.options?.isHorizontalLayout || false
         })
     const { client } = useOpenNMSClient(internalOptions?.datasource?.value)
  
@@ -39,7 +42,8 @@ export const FilterPanelOptions: React.FC<PanelOptionsEditorProps<FilterPanelOpt
           if (data && data.datasource && data.activeFilters) {
               setInternalOptions({
                   datasource: data.datasource,
-                  activeFilters: data.activeFilters
+                  activeFilters: data.activeFilters,
+                  isHorizontalLayout: data.isHorizontalLayout
               })
           }
         }
@@ -65,6 +69,10 @@ export const FilterPanelOptions: React.FC<PanelOptionsEditorProps<FilterPanelOpt
               `
             }
             </style>
+            <FilterPanelLayoutOptions
+                isHorizontal={internalOptions.isHorizontalLayout}
+                onChange={(d) => onOptionChange(d, 'isHorizontalLayout')}
+            />
             <FilterPanelDataSource
                 onChange={(d) => onOptionChange(d, 'datasource')}
                 datasource={internalOptions.datasource}

--- a/src/panels/filter-panel/FilterPanelTypes.ts
+++ b/src/panels/filter-panel/FilterPanelTypes.ts
@@ -3,9 +3,10 @@ import { GrafanaDatasource } from 'hooks/useDataSources'
 import { ActiveFilter } from '../../datasources/entity-ds/types'
 
 export interface FilterControlProps {
-    dashboardUid?: string
-    filterEditor: {
-        datasource: SelectableValue<GrafanaDatasource> | undefined,
-        activeFilters: ActiveFilter[]
-    }
+  dashboardUid?: string
+  filterEditor: {
+    datasource: SelectableValue<GrafanaDatasource> | undefined,
+    activeFilters: ActiveFilter[],
+    isHorizontalLayout?: boolean
+  }
 }


### PR DESCRIPTION
Add a Horizontal layout option to the Filter Panel.

The v8 Filter Panel had a horizontal layout, i.e. all items in a single, wrapping row. v9 by default has a vertical layout, each item label/value is on its own row, which is generally more readable. However there may be situations in which users prefer a horizontal layout.

Note also that the vertical layout does scroll vertically so all items can be accessed (the initial issue in HELM-439).

Code for the fields themselves was refactored into `FilterPanelControlField.tsx` to allow reuse.

# External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/HELM-439
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
