### PR TITLE
HELM-438: Dashboard converter retains original datasource name/label/uid

### DIFF
--- a/src/lib/dashboard-convert/datasources.ts
+++ b/src/lib/dashboard-convert/datasources.ts
@@ -4,7 +4,7 @@ import { getDatasourceTypeFromPluginId } from './utils'
 import { isString } from '../utils'
 
 // Datasource info found in panel or target/query
-interface SourceDatasourceInfo {
+export interface SourceDatasourceInfo {
   isOpenNmsDatasource: boolean
   isTemplateVariable: boolean
   datasourceType: string
@@ -52,13 +52,15 @@ export const getSourceDatasourceInfo = (source: any, datasourceMap: Map<string,D
         datasourceType: dsType
       }
     } else if (!isString(source.datasource) && source.datasource?.type) {
-      // 2. datasource is an object with type
+      // 2. datasource is an object with type, and may also have a template variable as uid
       const { datasourceType } = getDatasourceTypeFromPluginId(source.datasource.type)
 
       if (datasourceType) {
+        const uid: string = source.datasource.uid || ''
+
         return {
           isOpenNmsDatasource: true,
-          isTemplateVariable: false,
+          isTemplateVariable: uid.startsWith('$'),
           datasourceType
         }
       }

--- a/src/lib/dashboard-convert/inputs.ts
+++ b/src/lib/dashboard-convert/inputs.ts
@@ -39,7 +39,9 @@ export const parseInputs = (source: any[], datasourceMap: Map<string,DsType>, ds
 
         if (dsMeta) {
           addVariationsToMap(name, datasourceType as DsType, datasourceMap)
-          target.label = dsMeta.name
+
+          // keep existing name and label if possible, they may distinguish between multiple datasource instances of the same type
+          target.label = target.label || dsMeta.name
           target.pluginId = dsMeta.type
           target.pluginName = dsMeta.name
 

--- a/src/lib/dashboard-convert/panels.ts
+++ b/src/lib/dashboard-convert/panels.ts
@@ -8,6 +8,7 @@ import { convertLegacyFilterPanel, isLegacyFilterPanel } from './filterPanel'
 import { updateFlowQuery } from './flowDs'
 import { updatePerformanceQuery } from './performanceDs'
 import { DatasourceMetadata, DsType } from './types'
+import { updateTargetDatasource } from './utils'
 
 // Convert Dashboard panels
 // If panel has a legacy datasource, convert the query to use the new schema
@@ -57,16 +58,7 @@ const convertPanelDatasources = (panel: any, datasourceMap: Map<string, DsType>,
   // - empty/null/undefined, in which case DS should be in the individual targets, leave as-is
   const panelDsInfo = getSourceDatasourceInfo(panel, datasourceMap)
 
-  if (panelDsInfo.isOpenNmsDatasource && !panelDsInfo.isTemplateVariable && panelDsInfo.datasourceType) {
-    const panelDsMeta = dsMetas.find(d => d.datasourceType === panelDsInfo.datasourceType && d.pluginVersion === 9)
-
-    if (panelDsMeta) {
-      panel.datasource = {
-        type: panelDsMeta.type,
-        uid: panelDsMeta.uid
-      }
-    }
-  }
+  updateTargetDatasource(panel, panelDsInfo, dsMetas)
 
   if (panel.targets) {
     const targets: any[] = []
@@ -96,16 +88,7 @@ const convertPanelDatasources = (panel: any, datasourceMap: Map<string, DsType>,
           updatedTarget.hide = false
         }
 
-        if (targetDsInfo.isOpenNmsDatasource && !targetDsInfo.isTemplateVariable && targetDsInfo.datasourceType) {
-          const targetDsMeta = dsMetas.find(d => d.datasourceType === targetDsInfo.datasourceType && d.pluginVersion === 9)
-
-          if (targetDsMeta) {
-            updatedTarget.datasource = {
-              type: targetDsMeta.type,
-              uid: targetDsMeta.uid
-            }
-          }
-        }
+        updateTargetDatasource(updatedTarget, targetDsInfo, dsMetas)
       }
 
       targets.push(updatedTarget)

--- a/src/lib/dashboard-convert/templating.ts
+++ b/src/lib/dashboard-convert/templating.ts
@@ -1,6 +1,6 @@
 import { getSourceDatasourceInfo } from './datasources'
 import { DatasourceMetadata, DsType } from './types'
-import { addVariationsToMap, getDatasourceTypeFromPluginId } from './utils'
+import { addVariationsToMap, getDatasourceTypeFromPluginId, updateTargetDatasource } from './utils'
 
 // Parse the Dashboard 'templating' section, extracting any Datasource mappings and
 // updating those items to use Version 9 versions
@@ -64,17 +64,7 @@ export const parseTemplating = (source: any, datasourceMap: Map<string,DsType>, 
       }
     } else if (s.type === 'query') {
       const sourceDsInfo = getSourceDatasourceInfo(s, datasourceMap)
-
-      if (sourceDsInfo.isOpenNmsDatasource && !sourceDsInfo.isTemplateVariable && sourceDsInfo.datasourceType) {
-        const sourceDsMeta = dsMetas.find(d => d.datasourceType === sourceDsInfo.datasourceType && d.pluginVersion === 9)
-
-        if (sourceDsMeta) {
-          s.datasource = {
-            type: sourceDsMeta.type,
-            uid: sourceDsMeta.uid
-          }
-        }
-      }
+      updateTargetDatasource(s, sourceDsInfo, dsMetas)
     }
 
     // was not an OpenNms datasource query, or we couldn't find a substitute, so just pass it through

--- a/src/lib/dashboard-convert/utils.ts
+++ b/src/lib/dashboard-convert/utils.ts
@@ -1,4 +1,5 @@
-import { DsType } from './types'
+import { SourceDatasourceInfo } from './datasources';
+import { DatasourceMetadata, DsType } from './types'
 
 // add 'name', '$name' and '${name}' variations
 export const addVariationsToMap = (varName: string, dsType: DsType,  datasourceMap: Map<string,DsType>) => {
@@ -44,4 +45,25 @@ export const getDashboardTitle = (json: string) => {
   }
 
   return ''
+}
+
+// Checks if the datasource for a source (panel, panel target, etc.) is an OpenNMS one and if so,
+// updates the type and uid
+// Will retain the original uid if it's a template variable, e.g. pointing to a datasource in '__inputs'.
+// sourceDsInfo is from calling getSourceDatasourceInfo(source, datasourceMap)
+// source may be a panel, panel.target, etc. which contains a 'datasource' field
+export const updateTargetDatasource = (source: any, sourceDsInfo: SourceDatasourceInfo, dsMetas: DatasourceMetadata[]) => {
+  if (sourceDsInfo.isOpenNmsDatasource && sourceDsInfo.datasourceType) {
+    const dsMeta = dsMetas.find(d => d.datasourceType === sourceDsInfo.datasourceType && d.pluginVersion === 9)
+
+    if (dsMeta) {
+      // retain the uid if it's a template variable
+      const dsUid = sourceDsInfo.isTemplateVariable && !!source.datasource.uid ? source.datasource.uid : dsMeta.uid
+
+      source.datasource = {
+        type: dsMeta.type,
+        uid: dsUid
+      }
+    }
+  }
 }


### PR DESCRIPTION
HELM-438: Dashboard converter retains original datasource name/label/uid when possible

Dashboard converter tool will retain the original datasource name and label if present, and if the datasource uid reference is a template or input variable, it will retain it instead of using the uid of the installed v9 datasource.

This will help in cases where multiple instances of an OpenNMS datasource are used, for example if they point to different OpenNMS instances.

# External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/HELM-438
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
