### PR TITLE
OPG-461: Include nodeid in ipinterface query results

### DIFF
--- a/src/datasources/entity-ds/EntityClause.tsx
+++ b/src/datasources/entity-ds/EntityClause.tsx
@@ -69,7 +69,8 @@ export const EntityClause = ({
         if (attribute?.value?.type?.i === 'TIMESTAMP') {
             type = 'datetime-local'
         } else if (attribute?.value?.type?.i === 'INTEGER') {
-            type = 'number'
+            // leaving this as 'text' for now, otherwise user cannot input template variable
+            // type = 'number'
         }
         return type;
     }
@@ -128,8 +129,8 @@ export const EntityClause = ({
             <Segment
                 allowEmptyValue={false}
                 value={clause.comparator}
-                onChange={(text) => {
-                    setComparator(index, text);
+                onChange={val => {
+                    setComparator(index, val)
                 }}
                 options={comparatorOptions}
             />

--- a/src/datasources/entity-ds/EntityClauseEditor.tsx
+++ b/src/datasources/entity-ds/EntityClauseEditor.tsx
@@ -19,26 +19,38 @@ export const EntityClauseEditor = ({ setFilter, loading, propertiesAsArray, clau
 
         // Build the filter. This could be extracted to a helper function.
         clauses.forEach((d, i) => {
-            if ((d.type === OnmsEntityType.AND || d.type === OnmsEntityType.FIRST) && clauses[i].comparator?.value) {
+            // comparator could be: '{ id, label }' or else '{ value: { i, l } }'
+            let comparatorValue = clauses[i].comparator?.value
+
+            if (!comparatorValue && clauses[i].comparator?.id) {
+              comparatorValue = {
+                id: clauses[i].comparator.id,
+                label: clauses[i].comparator.label,
+                l: clauses[i].comparator.label,
+                i: clauses[i].comparator.id
+              }
+            }
+
+            if ((d.type === OnmsEntityType.AND || d.type === OnmsEntityType.FIRST) && comparatorValue) {
                 updatedFilter.withAndRestriction(
                     new API.Restriction(
                         clauses[i].attribute?.value?.id,
-                        clauses[i].comparator?.value,
+                        comparatorValue,
                         clauses[i].comparedString || clauses[i].comparedValue.value
                     )
                 )
-            } else if (d.type === OnmsEntityType.OR && clauses[i].comparator?.value) {
+            } else if (d.type === OnmsEntityType.OR && comparatorValue) {
                 updatedFilter.withOrRestriction(
                     new API.Restriction(
                         clauses[i].attribute?.value?.id,
-                        clauses[i].comparator?.value,
+                        comparatorValue,
                         clauses[i].comparedString || clauses[i].comparedValue.value
                     )
                 )
             }
         })
         
-        setFilter(updatedFilter);
+        setFilter(updatedFilter)
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [clauses])
 

--- a/src/datasources/entity-ds/EntityQueryEditor.tsx
+++ b/src/datasources/entity-ds/EntityQueryEditor.tsx
@@ -63,6 +63,7 @@ const clausesReducer = (clauses: OnmsEntityClause[], action: Action): OnmsEntity
         default:
             throw new Error("shouldn't get here")
     }
+
     return newClauses
 }
 

--- a/src/datasources/entity-ds/queries/queryIPInterfaces.ts
+++ b/src/datasources/entity-ds/queries/queryIPInterfaces.ts
@@ -18,6 +18,7 @@ const columns = Object.freeze([
     { text: 'SNMP ifDescr', resource: 'snmpInterface.ifDescr' },
     { text: 'SNMP ifIndex', resource: 'snmpInterface.ifIndex' },
     { text: 'SNMP PhysAddr', resource: 'snmpInterface.physAddr' },
+    { text: 'Node ID', resource: 'node.id' }
 ] as OnmsColumn[]);
 
 export const getIPInterfaceColumns = () => columns
@@ -47,6 +48,7 @@ export const queryIPInterfaces = async (client: ClientDelegate, filter: API.Filt
             iface.snmpInterface?.ifDescr,
             iface.snmpInterface?.ifIndex,
             iface.snmpInterface?.physAddr?.toString(),
+            iface.node?.id
         ];
     });
 

--- a/src/test/react/flow_ds_datasource.spec.ts
+++ b/src/test/react/flow_ds_datasource.spec.ts
@@ -1,4 +1,4 @@
-import { dateTimeAsMoment } from '@grafana/data'
+import { dateTimeAsMoment, ArrayVector } from '@grafana/data'
 import { OnmsFlowSeries } from 'opennms/src/model'
 import *  as helpers from '../../datasources/flow-ds/helpers'
 import {
@@ -633,25 +633,25 @@ describe("OpenNMS_Flow_Datasource", function () {
       done();
     });
 
-    it("should Swap Ingress/Egress and convert toBits, labels in response to Grafana series", function (done) {
+    it('should Swap Ingress/Egress and convert toBits, labels in response to Grafana series', function (done) {
       dataFromOpenNMS = {
-        "start": null,
-        "end": null,
-        "headers": [
-          "Application",
-          "Bytes In",
-          "Bytes Out",
-          "ECN"
+        start: null,
+        end: null,
+        headers: [
+          'Application',
+          'Bytes In',
+          'Bytes Out',
+          'ECN'
         ],
-        "rows": [
+        rows: [
           [
-            "app0",
+            'app0',
             1,
             2,
             3
           ],
           [
-            "app1",
+            'app1',
             5,
             null,
             3
@@ -671,42 +671,52 @@ describe("OpenNMS_Flow_Datasource", function () {
           ],
           refId: ''
         }
-      ] as FlowParsedQueryData;
+      ] as FlowParsedQueryData
 
-      let expectedResponse = [{
+      const expectedResponse = [{
         name: '',
-        "fields": [
+        refId: '',
+        fields: [
           {
-            "name": "Application",
-            "values": ["app0", "app1"]
+            name: 'Application',
+            values: new ArrayVector(['app0', 'app1']),
+            config: {},
+            type: 'number'
           },
           {
-            "name": "Bits In",
-            "values": [16, 0]
+            name: 'Bits In',
+            values: new ArrayVector([16, 0]),
+            config: {},
+            type: 'number'
           },
           {
-            "name": "Bits Out",
-            "values": [8, 40]
+            name: 'Bits Out',
+            values: new ArrayVector([8, 40]),
+            config: {},
+            type: 'number'
           },
           {
-            "name": "ECN",
-            "values": ["non-ect / ce", "non-ect / ce"]
+            name: 'ECN',
+            values: new ArrayVector(['non-ect / ce', 'non-ect / ce']),
+            config: {},
+            type: 'number'
           }
         ],
-        "meta": {
-          "custom": {
-            "metric": "",
-            "toBits": ""
+        length: 2,
+        meta: {
+          custom: {
+            metric: '',
+            toBits: ''
           },
         },
-      }];
-      let actualResponse = helpers.processDataBasedOnType(FlowStrings.summaries, fullQueryData[0], options, dataFromOpenNMS);
-      expect(expectedResponse).toEqual(actualResponse);
-      done();
-    });
+      }]
+
+      const actualResponse = helpers.processDataBasedOnType(FlowStrings.summaries, fullQueryData[0], options, dataFromOpenNMS)
+      expect(expectedResponse).toEqual(actualResponse)
+      done()
+    })
 
     it("should combine multiple with uneven qty of ingress and egress when set", function (done) {
-
       fullQueryData = [
         {
           segment: {


### PR DESCRIPTION
Include the node ID in IP interface Entity Datasource query results. Note that node label is not in the underlying Rest API and was not previously available in Helm v8.

Also fixed a few other issues:

- changed clause value input type to 'text' instead of 'number', even if value is a number. This was preventing users from using a template variable in this field
- fixed some issues with comparator handling which was preventing clauses from being converted to filters and sent in the Rest API call
- flow unit test

# External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/OPG-461
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
