### PR TITLE
OPG-448: Dashboard converter was outputting extra bracket

### DIFF
--- a/src/lib/dashboard-convert/performanceDs.ts
+++ b/src/lib/dashboard-convert/performanceDs.ts
@@ -272,7 +272,7 @@ const convertStringPropertyQuery = (source: any) => {
 
   // 'label' and 'name' will be filled in at runtime
   const resourceState = {
-    id: `node[${legacyNodeId}].${legacyResourceId}]`,
+    id: `node[${legacyNodeId}].${legacyResourceId}`,
     label: legacyResourceId,
     parentId: `node[${legacyNodeId}]`
   }


### PR DESCRIPTION
Dashboard converter was outputting an extra right bracket `]` in `stringPropertyState.resource.id`.

# External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/OPG-448
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
