### PR TITLE
OPG-454: Allow Flows query with multi-valued withHost

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -337,12 +337,24 @@ export const trimChar = (str: string, sStart: string, sEnd?: string) => {
   return result
 }
 
-export const getMultiValues = (values: string): string[]  => {
-  if (!isString(values)) {
-    values = String(values)
+export const isMultiValueString = (value: any): boolean => {
+  if (isString(value)) {
+    const s = value as string
+
+    return s.startsWith('{') && s.endsWith('}')
   }
 
-  return trimChar(values, '{', '}').split(',')
+  return false
+}
+
+export const getMultiValues = (values: string | undefined): string[] => {
+  if (isUndefined(values)) {
+    return []
+  }
+
+  const valuesStr = !isString(values) ? String(values) : values as string
+
+  return trimChar(valuesStr, '{', '}').split(',')
 }
 
 export const capitalize = (value: string) => {


### PR DESCRIPTION
Allow 'withHost' Flows queries with multi-valued parameters for the 'host' value.

Needed to convert the `withHost` parameter from a string to an array, e.g. from `withHost: '{host1,host2}'` to `withHost: ['host1', 'host2']`

This was causing `opennms-js` Rest API call to be:

```
http://localhost:3000/api/datasources/proxy/uid/some-id/rest/flows/hosts/series?start=1694178697745&end=1694200297745&step=30989&host={0.0.0.0,0.0.0.1}
```

instead of

```
http://localhost:3000/api/datasources/proxy/uid/some-id/rest/flows/hosts/series?start=1694178697745&end=1694200297745&step=30989&host=0.0.0.0&host=0.0.0.1
```

Also fixed another issue getting interfaces if nodes was a multi-valued variable.

There are other places where we may not handle multi-valued variables correctly, may refactor a bit as we find those.

# External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/OPG-454
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
