### PR TITLE
OPG-464: Add nodeID to EntityDS SnmpInterfaces queries, IP nodeId column placement

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -3,7 +3,7 @@ version: '9'
 title: Plugin for Grafana
 asciidoc:
   attributes:
-    full-display-version: '9.0.9-SNAPSHOT'
+    full-display-version: '9.0.10-SNAPSHOT'
     grafana-version-required: '9.x'
     grafana-version-tested: '9.0'
     node-js-build-version: '16.x'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opennms-grafana-plugin",
-  "version": "9.0.9-SNAPSHOT",
+  "version": "9.0.10-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opennms-grafana-plugin",
-      "version": "9.0.9-SNAPSHOT",
+      "version": "9.0.10-SNAPSHOT",
       "license": "MIT",
       "dependencies": {
         "@emotion/css": "^11.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opennms-grafana-plugin",
-  "version": "9.0.9-SNAPSHOT",
+  "version": "9.0.10-SNAPSHOT",
   "description": "An OpenNMS Integration for Grafana",
   "repository": {
     "type": "git",

--- a/site.yml
+++ b/site.yml
@@ -14,7 +14,7 @@ asciidoc:
   attributes:
     experimental: true
     stem: latexmath
-    full-display-version: '9.0.9-SNAPSHOT'
+    full-display-version: '9.0.10-SNAPSHOT'
     grafana-version-required: '9.x'
     grafana-version-tested: '9.0'
     node-js-build-version: '16.x'

--- a/src/datasources/entity-ds/queries/queryIPInterfaces.ts
+++ b/src/datasources/entity-ds/queries/queryIPInterfaces.ts
@@ -7,6 +7,7 @@ const columns = Object.freeze([
     { text: 'ID', resource: 'id' },
     { text: 'IP Address', resource: 'ipAddress', featured: true, },
     { text: 'Hostname', resource: 'hostname', featured: true, },
+    { text: 'Node ID', resource: 'node.id' },
     { text: 'Is Down?', resource: 'isDown', },
     { text: 'Is Managed?', resource: 'isManaged', },
     { text: 'Last Capsd Poll', resource: 'lastCapsdPoll', },
@@ -17,8 +18,7 @@ const columns = Object.freeze([
     { text: 'SNMP ifAlias', resource: 'snmpInterface.ifAlias' },
     { text: 'SNMP ifDescr', resource: 'snmpInterface.ifDescr' },
     { text: 'SNMP ifIndex', resource: 'snmpInterface.ifIndex' },
-    { text: 'SNMP PhysAddr', resource: 'snmpInterface.physAddr' },
-    { text: 'Node ID', resource: 'node.id' }
+    { text: 'SNMP PhysAddr', resource: 'snmpInterface.physAddr' }
 ] as OnmsColumn[]);
 
 export const getIPInterfaceColumns = () => columns
@@ -37,6 +37,7 @@ export const queryIPInterfaces = async (client: ClientDelegate, filter: API.Filt
             iface.id,
             iface.ipAddress?.correctForm(),
             iface.hostname,
+            iface.node?.id,
             iface.isDown,
             iface.isManaged?.toDisplayString(),
             iface.lastCapsdPoll,
@@ -47,8 +48,7 @@ export const queryIPInterfaces = async (client: ClientDelegate, filter: API.Filt
             iface.snmpInterface?.ifAlias,
             iface.snmpInterface?.ifDescr,
             iface.snmpInterface?.ifIndex,
-            iface.snmpInterface?.physAddr?.toString(),
-            iface.node?.id
+            iface.snmpInterface?.physAddr?.toString()
         ];
     });
 

--- a/src/datasources/entity-ds/queries/querySNMPInterfaces.ts
+++ b/src/datasources/entity-ds/queries/querySNMPInterfaces.ts
@@ -1,11 +1,12 @@
-import { OnmsColumn, OnmsTableData } from '../types'
-import { OnmsSnmpInterface } from "opennms/src/model/OnmsSnmpInterface";
-import { ClientDelegate } from "lib/client_delegate";
 import { API } from 'opennms'
+import { OnmsSnmpInterface } from "opennms/src/model/OnmsSnmpInterface"
+import { OnmsColumn, OnmsTableData } from '../types'
+import { ClientDelegate } from "lib/client_delegate"
 
 const columns = Object.freeze([
     { text: 'ID', resource: 'id' },
     { text: 'Index', resource: 'ifIndex' },
+    { text: 'Node ID', resource: 'nodeId' },
     { text: 'Description', resource: 'ifDescr', featured: true },
     { text: 'Type', resource: 'ifType' },
     { text: 'Name', resource: 'ifName', featured: true },
@@ -18,23 +19,24 @@ const columns = Object.freeze([
     { text: 'Polled?', resource: 'poll' },
     { text: 'Last SNMP Poll', resource: 'lastSnmpPoll' },
     { text: 'Physical Address', resource: 'physAddr' }
-] as OnmsColumn[]);
+] as OnmsColumn[])
 
 export const getSNMPInterfaceColumns = () => columns
 
 export const querySNMPInterfaces = async (client: ClientDelegate, filter: API.Filter): Promise<OnmsTableData> => {
-    let ifaces: OnmsSnmpInterface[] = [];
+    let ifaces: OnmsSnmpInterface[] = []
 
     try {
-        ifaces = await client.findSnmpInterfaces(filter);
+        ifaces = await client.findSnmpInterfaces(filter)
     } catch (e) {
-        console.error(e);
+        console.error(e)
     }
 
     const rows = ifaces?.map((iface: OnmsSnmpInterface) => {
         return [
             iface.id,
             iface.ifIndex,
+            iface.nodeId,
             iface.ifDescr,
             iface.ifType,
             iface.ifName,
@@ -46,9 +48,9 @@ export const querySNMPInterfaces = async (client: ClientDelegate, filter: API.Fi
             iface.collect?.toDisplayString(),
             iface.poll,
             iface.lastSnmpPoll,
-            iface.physAddr?.toString(),
-        ];
-    });
+            iface.physAddr?.toString()
+        ]
+    })
 
     return {
         name: 'snmpInterfaces',

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -24,7 +24,7 @@
       {"name": "Metrics", "path": "img/Helm_Screenshot_Metrics.png"},
       {"name": "Performance Data Source", "path": "img/Helm_Screenshot_Performance_Data_Source.png"}
     ],
-    "version": "9.0.9-SNAPSHOT",
+    "version": "9.0.10-SNAPSHOT",
     "updated": "2023-08-11"
   },
   "includes": [


### PR DESCRIPTION
Part of OPG-464:

- add `nodeId` to Entity data source SnmpInterfaces query
- node `nodeId` column for IP Interfaces query results

There are more issues in OPG-464 but they require changes to both OpenNMS/Horizon as well as `opennms-js` first.

Update: removed adding `ipInterfaceId` to Monitored Services query results, needs to be added to `opennms-js` first. Also bumped snapshot to 9.0.10.

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/OPG-464
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
