### PR TITLE
OPG-464: Add fields to monitored services

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "flot-axislabels": "https://github.com/j-white/flot-axislabels#master",
         "lodash.clonedeep": "^4.5.0",
         "lodash.escaperegexp": "^4.1.2",
-        "opennms": "^2.5.6",
+        "opennms": "^2.5.8",
         "parenthesis": "^3.1.7",
         "perfect-scrollbar": "^1.5.5",
         "q": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "flot-axislabels": "https://github.com/j-white/flot-axislabels#master",
     "lodash.clonedeep": "^4.5.0",
     "lodash.escaperegexp": "^4.1.2",
-    "opennms": "^2.5.6",
+    "opennms": "^2.5.8",
     "parenthesis": "^3.1.7",
     "perfect-scrollbar": "^1.5.5",
     "q": "^1.5.1",

--- a/src/datasources/entity-ds/queries/queryMonitoredServices.ts
+++ b/src/datasources/entity-ds/queries/queryMonitoredServices.ts
@@ -7,9 +7,13 @@ const columns = Object.freeze([
     { text: 'ID', resource: 'id' },
     { text: 'Last Failed Poll', resource: 'lastFail' },
     { text: 'Last Good Poll', resource: 'lastGood' },
-    { text: 'IP Address', resource: 'ipInterface.ipAddress', featured: true },
+    { text: 'IP Address', resource: 'ipAddress', featured: true },
     { text: 'Type', resource: 'type.name', featured: true },
-    { text: 'Status', resource: 'status.id', featured: true }
+    { text: 'Status', resource: 'status.id', featured: true },
+    { text: 'Down', resource: 'down' },
+    { text: 'IP Interface ID', resource: 'ipInterfaceId' },
+    { text: 'Node ID', resource: 'nodeId' },
+    { text: 'Node Label', resource: 'nodeLabel' }
 ] as OnmsColumn[]);
 
 export const getMonitoredServicesColumns = () => columns
@@ -28,9 +32,13 @@ export const queryMonitoredServices = async (client: ClientDelegate, filter: API
             service.id,
             service.lastFail,
             service.lastGood,
-            service.ipInterface?.ipAddress?.correctForm(),
+            service.ipAddress || '',
             service.type?.name,
             service.status?.toDisplayString(),
+            service.down,
+            service.ipInterfaceId,
+            service.nodeId,
+            service.nodeLabel
         ];
     });
 


### PR DESCRIPTION
2nd part of OPG-464, added `ipAddress`, `down`, `ipInterfaceId`, `nodeId`, `nodeLabel` to EntityDS, Monitored Services. These were waiting on updates to Horizon and to `opennms-js`.

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/OPG-464
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
