### PR TITLE
OPG-470: Alarm Panel auto refresh after action

### DIFF
--- a/src/panels/alarm-table/AlarmTableAdditional.tsx
+++ b/src/panels/alarm-table/AlarmTableAdditional.tsx
@@ -11,15 +11,32 @@ interface AlarmTableAdditionalProps {
     context: any;
 }
 
+/** Build the default AlarmTableAdditionalState, enabling autoRefresh by default. */
+const buildDefaultState = (state: AlarmTableAdditionalState | undefined) => {
+  if (state) {
+    return {
+      ...state,
+      autoRefresh: state.autoRefresh === undefined ? true : state.autoRefresh
+    }
+  }
+
+  return { autoRefresh: true, useGrafanaUser: false }
+}
+
 export const AlarmTableAdditional: React.FC<AlarmTableAdditionalProps> = ({ onChange, context }) => {
-    const [alarmTableAdditional, setAlarmTableAdditional] = useState<AlarmTableAdditionalState>(context?.options?.alarmTable?.alarmTableAdditional || 
-      { useGrafanaUser: false })
-    const tooltipText = 'Used to control whether operations on alarms are performed the data source user, ' +
+    const [alarmTableAdditional, setAlarmTableAdditional] = useState<AlarmTableAdditionalState>(
+      buildDefaultState(context?.options?.alarmTable?.alarmTableAdditional)
+    )
+
+    const userGrafanaUserTooltipText = 'Used to control whether operations on alarms are performed the data source user, ' +
       'or the user that is currently logged in to Grafana. ' +
       'Supported operations are escalating, clearing, un-acknowledging alarms ' +
       'as well as creating/updating a journal/memo. ' +
       'NOTE: The data source must be configured using an user with the \'admin\' role ' +
       'in order to perform actions as other users.'
+
+    const autoRefreshTooltipText = 'Enables auto-refresh after performing an action such as acknowledge, clear or escalate. ' +
+      'NOTE: This will refresh the entire dashboard.'
 
     useEffect(() => {
         onChange(alarmTableAdditional);
@@ -35,7 +52,7 @@ export const AlarmTableAdditional: React.FC<AlarmTableAdditionalProps> = ({ onCh
     return (
       <div>
         <InlineFieldRow>
-          <InlineField label='Use Grafana user' tooltip={tooltipText}>
+          <InlineField label='Use Grafana user' tooltip={userGrafanaUserTooltipText}>
             <div style={{ display: 'flex', alignItems: 'center', height: '32px' }}>
               <Switch
                 value={alarmTableAdditional.useGrafanaUser}
@@ -43,6 +60,15 @@ export const AlarmTableAdditional: React.FC<AlarmTableAdditionalProps> = ({ onCh
             </div>
           </InlineField>
         </InlineFieldRow>
-      </div>
+        <InlineFieldRow>
+          <InlineField label='Auto refresh' tooltip={autoRefreshTooltipText}>
+            <div style={{ display: 'flex', alignItems: 'center', height: '32px' }}>
+              <Switch
+                value={alarmTableAdditional.autoRefresh}
+                onChange={() => setAlarmTableState('autoRefresh', !alarmTableAdditional.autoRefresh)} />
+            </div>
+          </InlineField>
+        </InlineFieldRow>
+       </div>
   )
 }

--- a/src/panels/alarm-table/AlarmTableTypes.ts
+++ b/src/panels/alarm-table/AlarmTableTypes.ts
@@ -6,6 +6,7 @@ export interface AlarmTableControlState {
 }
 
 export interface AlarmTableAdditionalState {
+  autoRefresh: boolean
   useGrafanaUser: boolean
 }
 


### PR DESCRIPTION
Adds an option to auto-refresh the Alarm Panel after performing an action such as `acknowledge`, `clear` or `escalate` on one or more alarms, so the user sees realtime updated data after performing the action (e.g. `Ack` field displays "true" instead of "false" after an `Acknowledge`).

The Grafana runtime does not appear to offer a way to refresh a panel or the dashboard programmatically, so here we "click" the "Refresh dashboard" button. Note, there could be issues if Grafana changes or removes this button in a future version (the `RefreshPicker` component).

Grafana React appears to have removed `getTimeSrv()` or any other access to the `TimeSrv` service, which includes `refreshTimeModel()` which could be used to refresh the query and panel. See [TimeSrv](https://github.com/grafana/grafana/blob/c3ebd388e3cc192590c3f4d381429f7d9e345765/public/app/features/dashboard/services/TimeSrv.ts#L250).

Using `PanelProps.onChangeTimeRange` kind of works, however it takes an `AbsoluteTimeRange` which contains `from` and `to` properties as timestamps. However, it does not contain the `raw` property of `TimeRange` which allows specifying things like `now` or `now-6M` ("Last 6 months"), so any call to `onChangeTimeRange` will replace that with an absolute time range, which would be undesirable from a user standpoint.

The Alarm Table Panel Options have been updated to enable/disable `autoRefresh`; it's enabled by default. Note that `autoRefresh` refreshes the entire current dashboard, so some users may wish to disable it.

Also added some explanatory comments for `useAlarmTableMenuActions`.

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/OPG-470
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
