### PR TITLE
OPG-469: Alarm Table panel custom column widths

### DIFF
--- a/src/panels/alarm-table/AlarmTableAdditional.tsx
+++ b/src/panels/alarm-table/AlarmTableAdditional.tsx
@@ -69,6 +69,6 @@ export const AlarmTableAdditional: React.FC<AlarmTableAdditionalProps> = ({ onCh
             </div>
           </InlineField>
         </InlineFieldRow>
-       </div>
+      </div>
   )
 }

--- a/src/panels/alarm-table/AlarmTableColumnSizes.tsx
+++ b/src/panels/alarm-table/AlarmTableColumnSizes.tsx
@@ -1,0 +1,150 @@
+import React, { useEffect, useState } from 'react'
+import {
+  Collapse,
+  InlineField,
+  InlineFieldRow,
+  Input,
+  Select,
+  Switch,
+  VerticalGroup
+} from '@grafana/ui'
+import { FieldDisplay } from 'components/FieldDisplay'
+import { AlarmTableColumnSizeItem, AlarmTableColumnSizeState } from './AlarmTableTypes'
+
+interface AlarmTableColumnSizeProps {
+    onChange: (state: AlarmTableColumnSizeState) => void
+    columnState: AlarmTableColumnSizeState | undefined
+    context: any
+}
+
+export const AlarmTableColumnSizes: React.FC<AlarmTableColumnSizeProps> = ({ onChange, columnState, context }) => {
+  const [isOpen, setIsOpen] = useState<boolean>(columnState?.active || false)
+  const [active, setActive] = useState<boolean>(columnState?.active || false)
+  const [columnSizes, setColumnSizes] = useState<AlarmTableColumnSizeItem[]>(columnState?.columnSizes || [])
+
+  const onAddColumn = (fieldName?: string) => {
+    if (fieldName && !columnSizes.some(c => c.fieldName === fieldName)) {
+      const newColumn = {
+        fieldName,
+        width: 100
+      }
+
+      const newColumns = [...columnSizes]
+      newColumns.push(newColumn)
+      setColumnSizes(newColumns)
+    }
+  }
+
+  const onChangeWidth = (field: AlarmTableColumnSizeItem, value: string) => {
+    if (value) {
+      const num = Number(value)
+
+      if (num && !Number.isNaN(num)) {
+        const newSizes = columnSizes.map(item => {
+          return item.fieldName === field.fieldName ? { fieldName: item.fieldName, width: num } : item
+        })
+      
+        setColumnSizes(newSizes)
+      }
+    }
+  }
+
+  const onRemove = (fieldName: string) => {
+    const newColumns = columnSizes.filter(item => item.fieldName !== fieldName)
+    setColumnSizes(newColumns)
+  }
+
+  useEffect(() => {
+    const newState = {
+      active,
+      columnSizes
+    }
+    onChange(newState);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active, columnSizes])
+
+  const tooltipText = 'Set fixed column widths for selected columns, which will retain their width ' +
+    'even when the Alarm Table panel is resized.'
+
+  return (
+    <>
+      <style>
+      {
+        `
+          .spacer {
+            margin-top: 1em;
+          }
+
+          .field-display-width {
+            width: 200px;
+          }
+
+          .button-remove {
+            margin-left: 6px;
+            background-color: rgb(239, 25, 32);
+            border-radius: 2px;
+            width: 22px;
+            height: 22px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin-right: 6px;
+            cursor: pointer;
+          }
+        `
+      }
+      </style>
+      <div className="spacer"></div>
+      <Collapse label="Column Sizes" collapsible={true} isOpen={isOpen} onToggle={() => setIsOpen(!isOpen)}>
+        <InlineFieldRow>
+          <InlineField label='Set column sizes' tooltip={tooltipText}>
+            <div style={{ display: 'flex', alignItems: 'center', height: '32px' }}>
+              <Switch
+                value={columnState?.active}
+                onChange={() => setActive(!active)} />
+            </div>
+          </InlineField>
+        </InlineFieldRow>
+
+        { columnState?.active &&
+          <InlineFieldRow>
+            <InlineField label='Add column'>
+              <Select
+                disabled={!columnState?.active}
+                placeholder='Add Column'
+                value={''}
+                onChange={val => onAddColumn(val.label)}
+                options={context?.data?.[0]?.fields.map((field, index) => ({ ...field, value: index, label: field.name }))}
+              />
+            </InlineField>
+          </InlineFieldRow>
+        }
+      
+        { columnState?.active ?
+          <div>
+            <VerticalGroup align='flex-start'>
+              {columnState?.columnSizes?.map((item, index) => {
+                return (
+                  <FieldDisplay key={item.fieldName}>
+                    <span className='field-display-width'>{index + 1}. {item.fieldName}</span>
+                    <Input type='number' width={12} value={item.width} onChange={(val) => onChangeWidth(item, val.currentTarget.value)} />
+                    <span
+                      className='button-remove'
+                      tabIndex={0}
+                      onClick={(e) => onRemove(item.fieldName)}
+                      onKeyUp={(e) => { e.key === ' ' && onRemove(item.fieldName) }}
+                    ><i className='fa fa-ban'></i></span>
+                  </FieldDisplay>
+                )
+              })}
+            </VerticalGroup>
+          </div>
+        :
+          <div className='spacer'>
+            No configured column sizes.
+          </div>
+        }
+      </Collapse>
+    </>
+  )
+}

--- a/src/panels/alarm-table/AlarmTableOptions.tsx
+++ b/src/panels/alarm-table/AlarmTableOptions.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { PanelOptionsEditorProps } from '@grafana/data'
 import { AlarmTableAdditional } from './AlarmTableAdditional'
 import { AlarmTableAlarms } from './AlarmTableAlarms'
+import { AlarmTableColumnSizes } from './AlarmTableColumnSizes'
 import { AlarmTableData } from './AlarmTableData'
 import { AlarmTablePaging } from './AlarmTablePaging'
 
@@ -27,6 +28,7 @@ export const AlarmTableOptions: React.FC<PanelOptionsEditorProps<{}>> = ({ conte
       <AlarmTableData context={context} onChange={(v) => onOptionChange(v, 'alarmTableData')} />
       <AlarmTablePaging context={context} onChange={(v) => onOptionChange(v, 'alarmTablePaging')} />
       <AlarmTableAlarms onChange={(v) => onOptionChange(v, 'alarmTableAlarms')} alarmTable={context.options?.alarmTable} />
+      <AlarmTableColumnSizes context={context} onChange={(v) => onOptionChange(v, 'alarmTableColumnSizes')} columnState={context.options?.alarmTable?.alarmTableColumnSizes} />
     </>
   )
 }

--- a/src/panels/alarm-table/AlarmTableTypes.ts
+++ b/src/panels/alarm-table/AlarmTableTypes.ts
@@ -27,12 +27,23 @@ export interface AlarmTablePaginationState {
   fontSize?: SelectableValue<string | number>
 }
 
+export interface AlarmTableColumnSizeItem {
+  fieldName: string
+  width: number
+}
+
+export interface AlarmTableColumnSizeState {
+  active: boolean
+  columnSizes: AlarmTableColumnSizeItem[]
+}
+
 export interface AlarmTableControlProps {
   alarmTable: {
-    alarmTableAdditional: AlarmTableAdditionalState,
-    alarmTableAlarms: AlarmTableAlarmDataState,
-    alarmTableData: AlarmTableAlarmDataState,
+    alarmTableAdditional: AlarmTableAdditionalState
+    alarmTableAlarms: AlarmTableAlarmDataState
+    alarmTableData: AlarmTableAlarmDataState
     alarmTablePaging: AlarmTablePaginationState
+    alarmTableColumnSizes?: AlarmTableColumnSizeState
   }
 }
 


### PR DESCRIPTION
Allow option to have custom column widths for the Alarm Table panel.

Grafana takes care of sizing the column widths for panels using the `Table` component, which we use in the Alarm Table, and doesn't seem to provide a way to retain or access those widths. If a user resizes a panel, Grafana will auto-size the column widths again. If that is not desired, then this option can be used.

Adds a new "Column Sizes" section to the panel options editor. User can enable/disable, add columns and set widths, in pixels, click on the red icon to delete.

<img width="1538" alt="alarm-panel-column-resize" src="https://github.com/OpenNMS/grafana-plugin/assets/1933710/fede0f96-b5cd-4662-921d-6e379cb1b6f6">

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/OPG-469
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
