### PR TITLE
OPG-468: Add labelFormat and valueFormat to EntityDS nodeFilter

### DIFF
--- a/src/datasources/entity-ds/constants.ts
+++ b/src/datasources/entity-ds/constants.ts
@@ -1,5 +1,4 @@
-
-import { OnmsEntityClause, OnmsEntityNestType, OnmsEntityType, SearchOption } from "./types"
+import { OnmsEntityClause, OnmsEntityNestType, OnmsEntityType, SearchOption } from './types'
 
 export const defaultClause = {
     attribute: {} as unknown as SearchOption,
@@ -11,3 +10,9 @@ export const defaultClause = {
 } as OnmsEntityClause
 
 export const defaultOrder = { label: 'DESC' }
+
+/**
+ * Valid formats for the 'text' or 'value' part of a Node metricFindQuery.
+ * Default is 'id'.
+ */
+export const validNodeValueFormats = ['id', 'label', 'id:label', 'label:id', 'fs:fid']

--- a/src/datasources/entity-ds/types.ts
+++ b/src/datasources/entity-ds/types.ts
@@ -156,6 +156,14 @@ export interface OnmsMetricFindValue extends MetricFindValue {
   label?: string
 }
 
+export interface OnmsEntityFunctionInfo {
+  entityType: string
+  funcName: string
+  attribute: string
+  labelFormat: string
+  valueFormat: string
+}
+
 export interface OnmsTableData extends TableData {
   // override
   columns: OnmsColumn[]

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -318,20 +318,54 @@ export const getResourceId = (resource): string => {
 }
 
 /**
- * Modify a string by trimming the starting and ending character(s) in a string passed in the arguments
- * If no ending character is defined will use start character as estart and end character(s).
- * @param str string to modify 
- * @param sStart character/string to trim at start of the string
- * @param sEnd character/string to trim at the end of a string
- * @returns the string without the start and end characters passed as argument (if they exist)
+ * Returns true if 'variable' appears to be a Grafana template variable, i.e. in the form '${var}' or '$var'.
  */
-export const trimChar = (str: string, sStart: string, sEnd?: string) => {
-  str = str.trim()
-  let result: string = str
-  sEnd ??= sStart
+export const isTemplateVariableCandidate = (variable: string) => {
+  variable = (variable || '').trim()
 
-  if (str.startsWith(sStart) && str.endsWith(sEnd)) {
-    result = str.substring(str.indexOf(sStart) + 1, str.lastIndexOf(sEnd))
+  return !!variable &&
+    (
+      (variable.startsWith('${') && variable.endsWith('}')) ||
+      (variable.startsWith('$') && !variable.includes('{') && !variable.includes('}'))
+    )
+}
+
+/**
+ * Given a Grafana template variable name in the form '$var' or '${var}', return 'var', i.e. the "raw" variable name.
+ */
+export const extractRawVariableName = (templateVar: string) => {
+  const trimmed = (templateVar || '').trim()
+
+  if (trimmed && trimmed.startsWith('$')) {
+    return trimChar(trimChar(trimmed, '$'), '{', '}')
+  }
+
+  return trimmed
+}
+
+/**
+ * Modify a string by trimming the starting and ending character(s) in a string passed in the arguments.
+ * Ending character is optional.
+ * @param str string to modify 
+ * @param start character/string to trim at start of the string
+ * @param end If specified, character/string to trim at the end of a string
+ * @returns the string without the start and end characters passed as arguments (if they exist)
+ */
+export const trimChar = (str: string, start: string, end?: string) => {
+  str = (str || '').trim()
+
+  if (!str || !start) {
+    return str
+  }
+
+  let result: string = str
+
+  if (str.startsWith(start) && (!end || str.endsWith(end))) {
+    if (end && end.length > 0) {
+      result = str.substring(str.indexOf(start) + 1, str.lastIndexOf(end))
+    } else {
+      result = str.substring(str.indexOf(start) + 1)
+    }
   }
 
   return result


### PR DESCRIPTION
First part of OPG-468.

Allows specifying a `labelFormat` and `valueFormat` for the Entity data source `nodeFilter()` query.

Can be one of ['id', 'label', 'id:label', 'label:id', 'fs:fid'] for either of these.

`labelFormat` is the format for display, for example in a template variable dropdown list or in the Preview of values.

`valueFormat` is the format of the value used to interpolate variables, send to the server, etc.

Additional attributes can be specified, as before, including template variables.

For example, specifying the template variable query
```javascript
nodeFilter(labelFormat=label,valueFormat=id,location=$location)
```
would filter nodes by the location specified in the template variable `$location`, display the node label and use the node id in a query.

This also includes a bug fix so that `nodeFilter` can have a template variable specified in an attribute clause, as well as some formatting and type specifier fixes.

Still need to apply this to Performance data source, will be a separate PR.

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/OPG-468
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
