### PR TITLE
OPG-468: Add labelFormat, valueFormat to PerfDS nodeFilter

### DIFF
--- a/src/datasources/perf-ds/PerformanceQueryEditor.tsx
+++ b/src/datasources/perf-ds/PerformanceQueryEditor.tsx
@@ -131,9 +131,10 @@ export const PerformanceQueryEditor: React.FC<PerformanceQueryEditorProps> = ({ 
         const resourceData = await datasource.doResourcesRequest(remoteResourceId)
 
         if (resourceData) {
-            return Object.entries(resourceData.rrdGraphAttributes).map(([key, item]: [string, OnmsRrdGraphAttribute]) => {
+            return Object.entries(resourceData.rrdGraphAttributes).map(([key, item]: [string, OnmsRrdGraphAttribute | any]) => {
                 return { ...(item as {}), label: key }
             })
+
         } else {
             return []
         }


### PR DESCRIPTION
Add `labelFormat` and `valueFormat` to the Performance data source `nodeFilter()` query.

Refactored some functions into `function_formatter.ts` and fixed a function name typo.

See PR #937 for more info.

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/OPG-468
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
