### PR TITLE
OPG-466: Allow template variable text format substitution when used in Entity queries

### DIFF
--- a/src/datasources/perf-ds/PerformanceDataSource.tsx
+++ b/src/datasources/perf-ds/PerformanceDataSource.tsx
@@ -253,16 +253,16 @@ export class PerformanceDataSource extends DataSourceApi<PerformanceQuery> {
      * @returns 
      */
     async doResourcesForNodeRequest(nodeId: string) {
-        const response = await this.simpleRequest.doOpenNMSRequest({
-            url: '/rest/resources/fornode/' + encodeURIComponent(nodeId),
-            method: 'GET'
-        })
+      const response = await this.simpleRequest.doOpenNMSRequest({
+        url: '/rest/resources/fornode/' + encodeURIComponent(nodeId),
+        method: 'GET'
+      })
 
-        return response && response.data ? response.data as OnmsResourceDto : null
+      return response && response.data ? response.data as OnmsResourceDto : null
     }
 
     async metricFindLocations() {
-        return await this.simpleRequest.getLocations();
+      return await this.simpleRequest.getLocations()
     }
 
     async metricFindNodeFilterQuery(query: string, labelFormat: string, valueFormat: string) {
@@ -278,22 +278,26 @@ export class PerformanceDataSource extends DataSourceApi<PerformanceQuery> {
         results.push({ text, value, expandable: true })
       })
 
+      // ensure template variable value displays (e.g. dropdowns) are in alphabetical order based on text label
+      results.sort((a, b) => a.text.localeCompare(b.text))
+
       return results
     }
 
     async metricFindNodeResourceQuery(query, ...options) {
-        let textProperty = "id", resourceType = '*', regex = null;
-        if (options.length > 0) {
-            textProperty = options[0];
-        }
-        if (options.length > 1) {
-            resourceType = options[1];
-        }
-        if (options.length > 2) {
-            regex = options[2];
-        }
+      let textProperty = 'id', resourceType = '*', regex = null
 
-        return await this.getNodeResources(query, textProperty, resourceType, regex)
+      if (options.length > 0) {
+        textProperty = options[0]
+      }
+      if (options.length > 1) {
+        resourceType = options[1]
+      }
+      if (options.length > 2) {
+        regex = options[2]
+      }
+
+      return await this.getNodeResources(query, textProperty, resourceType, regex)
     }
 
     async getNodeResources(nodes: string, textProperty: string, resourceType: string, regex?: string | null) {

--- a/src/datasources/perf-ds/types.ts
+++ b/src/datasources/perf-ds/types.ts
@@ -1,6 +1,6 @@
 
-import { DataQuery, DataQueryRequest, DataSourceJsonData, QueryEditorProps, QueryResultMeta, SelectableValue } from "@grafana/data";
-import { PerformanceDataSource } from "./PerformanceDataSource";
+import { DataQuery, DataQueryRequest, DataSourceJsonData, QueryEditorProps, QueryResultMeta, SelectableValue } from '@grafana/data'
+import { PerformanceDataSource } from './PerformanceDataSource'
 
 /**
  * These are options configured for each DataSource instance


### PR DESCRIPTION
If a template variable is used in an Entity query, and the template variable specifies a `text` format specifier, e.g. `${node:text}`, make sure to use that `text` value rather than the `value` value for creating the query clause, for both single-valued and multi-valued template variables.

Example: you define a template variable `node` using a Performance datasource, `nodeFilter()` query, with `Multi-value` turned on. This will result (after PerfDS `metricFindQuery`) in the templateVariable `current` field (a `@grafana/data VariableOption` object) to have the node `label` in the `text` value array and node `fs:fid` in the `value` value array.

Then in say an Alarm Table panel, you define an Entity query on Alarms with a clause that the `Node: Label` equals `${node:text}`. This should match, since the template variable current `text` should contain the `node.label`, but if the `:text` is not recognized, it will match based on the template variable current `value` field containing the node `fs:fid`, which will fail.

For non-multi-valued items, the Grafana `templateSrv` is called to get the values and it will perform this substitution, but for multi-valued items, we do additional processing, which was not doing this but rather choosing `templateVariable.current.value` always, instead of `templateVariable.current.text`. This fixes that bug.

Also, sorts the result of Performance data source `nodeFilter` queries based on the `text` value.

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/OPG-466
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
