### PR TITLE
OPG-473: Fix Alarm Panel bug when calculating page rows

### DIFF
--- a/src/panels/alarm-table/hooks/useAlarmProperties.ts
+++ b/src/panels/alarm-table/hooks/useAlarmProperties.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { ArrayVector, DataFrame } from '@grafana/data'
+import { ArrayVector, DataFrame, Field } from '@grafana/data'
 import cloneDeep from 'lodash/cloneDeep'
 import { AlarmTableColumnSizeItem } from '../AlarmTableTypes'
 
@@ -73,12 +73,16 @@ export const useAlarmProperties = (oldProperties: DataFrame, alarmTable) => {
             if (rowsPerPage > 0 && totalRows > rowsPerPage) {
                 const myPage = page
 
-                filteredProps.fields = filteredProps.fields.map((field) => {
-                    const oldValues = [...field.values.buffer]
+                filteredProps.fields = filteredProps.fields.map((field: Field) => {
+                    // field.values is a Vector<any>, safest to call 'toArray()'
+                    // rather than assume it's an ArrayVector with a 'buffer' field
+                    const values = field.values.toArray()
                     const start = (myPage - 1) * rowsPerPage
                     const end = start + rowsPerPage
-                    const spliced = oldValues.splice(start, end)
-                    field.values = new ArrayVector(spliced) 
+
+                    const sliced = values.length > start ? values.slice(start, end) : []
+                    field.values = new ArrayVector(sliced)
+
                     return field
                 })
 


### PR DESCRIPTION
Fixed a bug in the Alarm Panel when calculating which rows of data to display for the given page.

Looks like we assumed `field.values` was always an `ArrayVector` having a `buffer` array field which we were accessing directly, however `field.values` is a `Vector` and might only contain `length` and `toArray()` fields. Using `toArray()` instead, and also cleaning up some code (use `slice()` instead of `splice()`, etc.).

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/OPG-473
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
