### PR TITLE
OPG-474: Display message after Alarm Table action

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "which": "^4.0.0"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "spec": {
     "specTemplate": "src/rpm/spec.mustache",

--- a/src/panels/alarm-table/AlarmTableAdditional.tsx
+++ b/src/panels/alarm-table/AlarmTableAdditional.tsx
@@ -11,16 +11,16 @@ interface AlarmTableAdditionalProps {
     context: any;
 }
 
-/** Build the default AlarmTableAdditionalState, enabling autoRefresh by default. */
+/** Build the default AlarmTableAdditionalState, enabling displayActionNotice by default. */
 const buildDefaultState = (state: AlarmTableAdditionalState | undefined) => {
   if (state) {
     return {
       ...state,
-      autoRefresh: state.autoRefresh === undefined ? true : state.autoRefresh
+      displayActionNotice: state.displayActionNotice === undefined ? true : state.displayActionNotice
     }
   }
 
-  return { autoRefresh: true, useGrafanaUser: false }
+  return { displayActionNotice: true, useGrafanaUser: false }
 }
 
 export const AlarmTableAdditional: React.FC<AlarmTableAdditionalProps> = ({ onChange, context }) => {
@@ -35,8 +35,8 @@ export const AlarmTableAdditional: React.FC<AlarmTableAdditionalProps> = ({ onCh
       'NOTE: The data source must be configured using an user with the \'admin\' role ' +
       'in order to perform actions as other users.'
 
-    const autoRefreshTooltipText = 'Enables auto-refresh after performing an action such as acknowledge, clear or escalate. ' +
-      'NOTE: This will refresh the entire dashboard.'
+    const actionNoticeTooltipText = 'Enables a notice to be displayed after performing an action such as acknowledge, clear or escalate ' +
+      'which will notify the user whether the action succeeded and prompt them to refresh the panel.'
 
     useEffect(() => {
         onChange(alarmTableAdditional);
@@ -61,11 +61,11 @@ export const AlarmTableAdditional: React.FC<AlarmTableAdditionalProps> = ({ onCh
           </InlineField>
         </InlineFieldRow>
         <InlineFieldRow>
-          <InlineField label='Auto refresh' tooltip={autoRefreshTooltipText}>
+          <InlineField label='Display action notice' tooltip={actionNoticeTooltipText}>
             <div style={{ display: 'flex', alignItems: 'center', height: '32px' }}>
               <Switch
-                value={alarmTableAdditional.autoRefresh}
-                onChange={() => setAlarmTableState('autoRefresh', !alarmTableAdditional.autoRefresh)} />
+                value={alarmTableAdditional.displayActionNotice}
+                onChange={() => setAlarmTableState('displayActionNotice', !alarmTableAdditional.displayActionNotice)} />
             </div>
           </InlineField>
         </InlineFieldRow>

--- a/src/panels/alarm-table/AlarmTableTypes.ts
+++ b/src/panels/alarm-table/AlarmTableTypes.ts
@@ -6,7 +6,7 @@ export interface AlarmTableControlState {
 }
 
 export interface AlarmTableAdditionalState {
-  autoRefresh: boolean
+  displayActionNotice: boolean
   useGrafanaUser: boolean
 }
 


### PR DESCRIPTION
Display a message after an Alarm Table menu action, such as `acknowledge`, `clear` or `escalate`.

Previously in #930 we "clicked" the Dashboard Refresh button to auto-refresh the Alarm Panel after performing an action, to display the current state. However, Grafana strongly discourages programmatically re-querying or refreshing (in fact, disallowed our change).

In this PR, a "toast" success or error message will appear after user performs an action; the `success` message notifies that user will need to manually refresh the panel to get the current alarm status.

Displaying the message is configurable in the panel Options editor; it's enabled by default.

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/OPG-474
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
