### PR TITLE
OPG-475: Fix nodeResources() arguments

### DIFF
--- a/src/datasources/perf-ds/PerformanceDataSource.tsx
+++ b/src/datasources/perf-ds/PerformanceDataSource.tsx
@@ -287,53 +287,67 @@ export class PerformanceDataSource extends DataSourceApi<PerformanceQuery> {
       return results
     }
 
-    async metricFindNodeResourceQuery(query, ...options) {
-      let textProperty = 'id', resourceType = '*', regex = null
+    async metricFindNodeResourceQuery(options: any[]) {
+      let query = ''
+      let textProperty = 'id'
+      let resourceType = '*'
+      let regex = null
 
       if (options.length > 0) {
-        textProperty = options[0]
+        query = options[0]
       }
       if (options.length > 1) {
-        resourceType = options[1]
+        textProperty = options[1]
       }
       if (options.length > 2) {
-        regex = options[2]
+        resourceType = options[2]
+      }
+      if (options.length > 3) {
+        regex = options[3]
+      }
+
+      if (!query) {
+        return []
       }
 
       return await this.getNodeResources(query, textProperty, resourceType, regex)
     }
 
     async getNodeResources(nodes: string, textProperty: string, resourceType: string, regex?: string | null) {
-
         const nodeResources = await this.simpleRequest.getResourcesFor(nodes)
         const results: MetricFindValue[] = []
 
         nodeResources.forEach((resource) => {
-            const resourceWithoutNodePrefix = resource.id.match(/node(Source)?\[.*?\]\.(.*)/);
+            const resourceWithoutNodePrefix = resource.id.match(/node(Source)?\[.*?\]\.(.*)/)
+
             if (!resourceWithoutNodePrefix) {
                 throw new Error(`No resources found for node: ${resource.id}`)
             }
-            let textValue;
+
+            let textValue
+
             switch (textProperty) {
-                case "id":
+                case 'id':
                     textValue = resourceWithoutNodePrefix[2]
                     break;
-                case "label":
+                case 'label':
                     textValue = resource.label
                     break;
-                case "name":
+                case 'name':
                     textValue = resource.name
                     break;
                 default:
                     textValue = resourceWithoutNodePrefix[2]
                     console.warn(`Unknown resource property '${textProperty}' specified. Using 'id' instead.`);
             }
+
             if (((resourceType === '*' && resourceWithoutNodePrefix) ||
                 (resourceWithoutNodePrefix[2].indexOf(resourceType + '[') === 0)) &&
                 (!regex || new RegExp(regex).test(textValue))) {
                 results.push({ text: textValue, value: resourceWithoutNodePrefix[2], expandable: true });
             }
         })
+
         return results
     }
 
@@ -343,6 +357,7 @@ export class PerformanceDataSource extends DataSourceApi<PerformanceQuery> {
         for (const source of sources) {
             const resourceId = this.templateSrv.replace(source.resourceId)
             const attribute = this.templateSrv.replace(source.attribute)
+
             if (OpenNMSGlob.hasGlob(attribute) || OpenNMSGlob.hasGlob(resourceId)) {
                 const extraQueries = await this.getSourcesFor(source)
                 if (extraQueries) {

--- a/src/lib/function_formatter.ts
+++ b/src/lib/function_formatter.ts
@@ -89,7 +89,7 @@ const _flatten = (args) => {
 /**
  * Process the raw output of `parenthesis.parse` to detect functions.
  */
-const _process = (args) => {
+const _process = (args: any[]) => {
   const ret = [] as any[]
   const matcher = /^(.*?)(\w+?)\($/          // NOSONAR: typescript:S5852
   let skip = false


### PR DESCRIPTION
Fixes a bug in `nodeResources()` (Performance data source), arguments were not being split correctly.

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/OPG-475
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
