### PR TITLE
OPG-477: Updates to Enable Input Value Override Components

### DIFF
--- a/docs/modules/datasources/pages/performance_datasource.adoc
+++ b/docs/modules/datasources/pages/performance_datasource.adoc
@@ -323,3 +323,16 @@ resourceToName($node, $interface) <1>
 
 The `resourceToInterface()` function transforms a resource ID, or a combination of node criteria and a partial resource ID, into another value.
 It is a special case of the other, more general methods; it takes the label of the resource (assumed to be an `interface-MAC` formatted string) and returns the interface portion of the label.
+
+== Datasource configuration options
+
+=== Enable Input Value Override Components
+
+When configuring a Performance Query, you provide values for types, nodes, resources, attributes, etc.
+Generally these are dropdown inputs with specific values, and may include template variables.
+In some cases, the dropdowns have validation that will only accept the displayed predefined values or text entered in a particular format.
+In these cases, it may be necessary or desirable to bypass these restrictions and enter a free-form text value or expression.
+
+If "Enable Input Override Components" is enabled in the Performance Datasource configuration page, then some inputs will display a switch, which if enabled will display a text input box to allow you to manually enter any text for that value. 
+
+This is disabled by default as it is generally not needed.

--- a/src/components/ValueOverrideSwitch.tsx
+++ b/src/components/ValueOverrideSwitch.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { InlineField, SegmentInput, Switch } from '@grafana/ui'
+import { InlineField, SegmentInput, InlineSwitch } from '@grafana/ui'
 
 export interface ValueOverrideSwitchProps {
   override: boolean
@@ -24,17 +24,16 @@ export const ValueOverrideSwitch = (props: ValueOverrideSwitchProps) => {
             display: flex;
             align-items: center;
             height: 32px;
-            width: 32px;
+            min-width: 32px;
         }
         .value-override-switch-field .value-override-switch-wrapper label {
             min-width: 32px;
-            width: 32px;
         }
       `}
     </style>
     <InlineField className='value-override-switch-field' label={props.label || defaultLabel} tooltip={props.tooltip || defaultTooltip}>
       <div className='value-override-switch-wrapper'>
-        <Switch
+        <InlineSwitch
           value={props.override}
           onChange={() => props.setOverride(!props.override)} />
       </div>

--- a/src/datasources/perf-ds/InputValueOverrideConfig.tsx
+++ b/src/datasources/perf-ds/InputValueOverrideConfig.tsx
@@ -1,6 +1,6 @@
 import React  from 'react'
 import { DataSourceSettings } from '@grafana/data'
-import { InlineField, Switch } from '@grafana/ui'
+import { InlineField, InlineSwitch } from '@grafana/ui'
 import { PerformanceDataSourceOptions } from './types'
 
 interface Props {
@@ -8,9 +8,9 @@ interface Props {
   options: DataSourceSettings<PerformanceDataSourceOptions>
 }
 
-export const ManualOverrideExtensionConfig: React.FC<Props> = ({ onOptionsChange, options}) => {
-  const tooltipText = 'Enable manual override UI components for some fields, e.g. Performance Attribute Node, ' +
-    'where you can enter a template variable or other value manually. ' +
+export const InputValueOverrideConfig: React.FC<Props> = ({ onOptionsChange, options}) => {
+  const tooltipText = 'Enable input value override UI components for some input fields, e.g. Performance Node or Attribute, ' +
+    'where you can enter a template variable, expression or other value manually, if it isn\'t allowed due to validation in the Select controls. ' +
     'Generally should not be needed.'
 
   const onChange = (value: boolean) => {
@@ -18,7 +18,7 @@ export const ManualOverrideExtensionConfig: React.FC<Props> = ({ onOptionsChange
       ...options,
       jsonData: {
         ...options.jsonData,
-       allowManualOverrideExtensions: value
+       enableInputValueOverrideComponents: value
       }
     }
 
@@ -48,12 +48,12 @@ export const ManualOverrideExtensionConfig: React.FC<Props> = ({ onOptionsChange
       }
       </style>
       <h3 className='spacer'>Additional Options</h3>
-      
-      <InlineField className='perf-config-editor-switch-field' label='Allow manual override extensions:' tooltip={tooltipText}>
+
+      <InlineField className='perf-config-editor-switch-field' label='Enable input value override components:' tooltip={tooltipText}>
         <div className='perf-config-editor-switch'>
-          <Switch
-            value={options.jsonData.allowManualOverrideExtensions}
-            onChange={() => onChange(!options.jsonData.allowManualOverrideExtensions)} />
+          <InlineSwitch
+            value={options.jsonData.enableInputValueOverrideComponents}
+            onChange={() => onChange(!options.jsonData.enableInputValueOverrideComponents)} />
         </div>
       </InlineField>
     </>

--- a/src/datasources/perf-ds/PerformanceAttribute.tsx
+++ b/src/datasources/perf-ds/PerformanceAttribute.tsx
@@ -8,7 +8,7 @@ import { OnmsResourceDto } from '../../lib/api_types'
 import { PerformanceAttributeItemState, PerformanceAttributeState } from './types'
 
 export interface PerformanceAttributesProps {
-    allowManualOverrideExtensions: boolean
+    enableInputValueOverrideComponents: boolean
     performanceAttributeState: PerformanceAttributeState
     updateQuery: Function
     loadNodes: (query?: string | undefined) => Promise<Array<SelectableValue<PerformanceAttributeItemState>>>
@@ -27,7 +27,7 @@ export const defaultPerformanceState: PerformanceAttributeState = {
 }
 
 export const PerformanceAttribute: React.FC<PerformanceAttributesProps> = ({
-    allowManualOverrideExtensions,
+    enableInputValueOverrideComponents,
     performanceAttributeState,
     updateQuery,
     loadNodes,
@@ -148,7 +148,7 @@ export const PerformanceAttribute: React.FC<PerformanceAttributesProps> = ({
                       })()
                     }}
                 />
-                { allowManualOverrideExtensions &&
+                { enableInputValueOverrideComponents &&
                   <ValueOverrideSwitch
                     override={isNodeOverride}
                     value={nodeOverrideValue}
@@ -168,7 +168,7 @@ export const PerformanceAttribute: React.FC<PerformanceAttributesProps> = ({
                         loadOptions={() => loadResourcesByNodeAndVariables(performanceState?.node?.id || performanceState?.node?.label)}
                         onChange={(value) => { setPerformanceStateProperty('resource', value) }}
                     />
-                    { allowManualOverrideExtensions &&
+                    { enableInputValueOverrideComponents &&
                       <ValueOverrideSwitch
                         override={isResourceOverride}
                         value={resourceOverrideValue}

--- a/src/datasources/perf-ds/PerformanceConfigEditor.tsx
+++ b/src/datasources/perf-ds/PerformanceConfigEditor.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import { DataSourceHttpSettings } from '@grafana/ui';
-import { ManualOverrideExtensionConfig } from './ManualOverrideExtensionConfig'
+import { InputValueOverrideConfig } from './InputValueOverrideConfig'
 import { PerformanceDataSourceOptions } from './types';
 
 interface Props extends DataSourcePluginOptionsEditorProps<PerformanceDataSourceOptions> { }
@@ -15,7 +15,7 @@ export const PerformanceConfigEditor: React.FC<Props> = ({ onOptionsChange, opti
               onChange={onOptionsChange}
           />
 
-          <ManualOverrideExtensionConfig
+          <InputValueOverrideConfig
             onOptionsChange={onOptionsChange}
             options={options}
           />

--- a/src/datasources/perf-ds/PerformanceDataSource.tsx
+++ b/src/datasources/perf-ds/PerformanceDataSource.tsx
@@ -34,7 +34,7 @@ export class PerformanceDataSource extends DataSourceApi<PerformanceQuery> {
     type: string
     url?: string
     name: string
-    allowManualOverrideExtensions: boolean
+    enableInputValueOverrideComponents: boolean
     client: ClientDelegate
     simpleRequest: SimpleOpenNMSRequest
     templateSrv: TemplateSrv
@@ -44,7 +44,7 @@ export class PerformanceDataSource extends DataSourceApi<PerformanceQuery> {
         this.type = instanceSettings.type
         this.url = instanceSettings.url
         this.name = instanceSettings.name
-        this.allowManualOverrideExtensions = instanceSettings.jsonData.allowManualOverrideExtensions || false
+        this.enableInputValueOverrideComponents = instanceSettings.jsonData.enableInputValueOverrideComponents || false
 
         this.client = new ClientDelegate(instanceSettings, getBackendSrv())
         this.simpleRequest = new SimpleOpenNMSRequest(getBackendSrv(), this.url)

--- a/src/datasources/perf-ds/PerformanceQueryEditor.tsx
+++ b/src/datasources/perf-ds/PerformanceQueryEditor.tsx
@@ -241,7 +241,7 @@ export const PerformanceQueryEditor: React.FC<PerformanceQueryEditorProps> = ({ 
                 isPerformanceType(PerformanceTypeOptions.Attribute.value) &&
 
                 <PerformanceAttribute
-                    allowManualOverrideExtensions={datasource.allowManualOverrideExtensions}
+                    enableInputValueOverrideComponents={datasource.enableInputValueOverrideComponents}
                     performanceAttributeState={query.attribute}
                     updateQuery={updateAttributeQuery}
                     loadNodes={loadNodes}

--- a/src/datasources/perf-ds/types.ts
+++ b/src/datasources/perf-ds/types.ts
@@ -7,7 +7,7 @@ import { PerformanceDataSource } from './PerformanceDataSource'
  */
 export interface PerformanceDataSourceOptions extends DataSourceJsonData {
   path?: string
-  allowManualOverrideExtensions?: boolean
+  enableInputValueOverrideComponents?: boolean
 }
 
 // TODO: check which of these are required


### PR DESCRIPTION
OPG-477: Updates to Enable Input Value Override Components implementation, naming and documentation

Makes Grafana-recommended fixes (`InlineSwitch` instead of `Switch`) as well as naming and documentation fixes for this feature.

This feature is an optional features, disabled by default, which allows a user to manually enter text input for some fields in a Performance Datasource query builder.

Usually values for nodes, attributes, resources, etc. display in a dropdown selection control, and some will also accept text input (e.g. a template variable or expression), but in some cases that kind of manual text input isn't accepted, for example due to validation on that input field. We've made improvements so that usually it **is** accepted, and also that for example template variables now generally display as predefined selection options, but in some cases, certain expressions may still not be accepted by the stock selection components. This is simply to allow user to manually enter any text in case that happens.

Generally it's not needed, but we wanted to include it as an option if a user is stuck not being able to enter a template variables, complex expressions, etc.

See https://github.com/OpenNMS/grafana-plugin/pull/953 for some more info on why this feature was added.

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/OPG-477
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
