### PR TITLE
OPG-478: Alarm Table pagination fixes for Grafana 9 and 10

### DIFF
--- a/src/panels/alarm-table/AlarmTableSelectionStyles.tsx
+++ b/src/panels/alarm-table/AlarmTableSelectionStyles.tsx
@@ -56,6 +56,16 @@ export const AlarmTableSelectionStyles = () => {
                             align-items:center;
                             justify-content:center;
                         }
+                        .alarm-table-wrapper {
+                            height: 90%;
+                        }
+                        .alarm-table-top-wrapper {
+                            height: 90%;
+                        }
+                        .alarm-table-pagination-wrapper {
+                            width: 100%;
+                            height: 10%;
+                        }
                         div[role="row"] {
                             border:1px solid transparent;
                             padding-bottom:1px;

--- a/src/panels/alarm-table/hooks/useAlarmTableMenu.ts
+++ b/src/panels/alarm-table/hooks/useAlarmTableMenu.ts
@@ -63,15 +63,17 @@ export const useAlarmTableMenu = (indexes: MutableRefObject<boolean[]>, rowClick
       }
     }
 
+    // apply click handlers to the table, but make sure they aren't applied to the Pagination component
     useEffect(() => {
         const currentTable = table.current
+        const tableWrapper = currentTable?.querySelector('div.alarm-table-wrapper')
 
-        table.current?.addEventListener('click', onTableClicked)
-        table.current?.addEventListener('contextmenu', onTableContextMenu)
+        tableWrapper?.addEventListener('click', onTableClicked)
+        tableWrapper?.addEventListener('contextmenu', onTableContextMenu)
 
         return () => {
-          currentTable?.removeEventListener('click', onTableClicked)
-          currentTable?.removeEventListener('contextmenu', onTableContextMenu)
+          tableWrapper?.removeEventListener('click', onTableClicked)
+          tableWrapper?.removeEventListener('contextmenu', onTableContextMenu)
         }
 
       // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Fix some Alarm Table pagination issues. Pagination controls were in some cases displaying but not clickable. 

This was due to use dynamically adding click handlers for the context menu to a `div` that included the `Pagination` control; this moves the control outside that `div`, among other fixes.

Tested with Grafana v9.4.7, v9.5.3, v10.4.2.

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/OPG-478
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
