### PR TITLE
OPG-488: Fix issue with Performance query variable interpolation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "opennms-grafana-plugin",
-      "version": "9.0.14",
+      "version": "9.0.15-SNAPSHOT",
       "license": "MIT",
       "dependencies": {
         "@emotion/css": "^11.1.3",

--- a/src/datasources/perf-ds/queries/interpolate.ts
+++ b/src/datasources/perf-ds/queries/interpolate.ts
@@ -146,10 +146,14 @@ const replaceQueryValueWithVariables = (queryValue: any, variables: Interpolatio
         }
 
         // check for '$variableName' syntax
-        const regexVarName = '\\$' + variable.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+        // we add word boundary at the end so we don't have spurious partial matches on variables
+        // having same beginning portion of name
+        let regexVarName = '\\$' + variable.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+        regexVarName = regexVarName + '\\b'
+
         interpolatedValue = interpolatedValue.replace(new RegExp(regexVarName, 'g'), variableValue)
 
-        // check for ${var} with optional {$var:format} where 'format' must be alphanumeric
+        // check for ${var} with optional ${var:format} where 'format' must be alphanumeric
         const regexWithBracesAndFormat = getVariableWithBracesReferencePattern(variable.name)
         interpolatedValue = interpolatedValue.replace(new RegExp(regexWithBracesAndFormat, 'g'), variableValue)
     })


### PR DESCRIPTION
If you add 2 variables to a Dashboard and they both have the same beginning of the variable name, then if you use the one with the longer name in a Performance query, the variable interpolation will end up doing a partial match on the shorter variable name and doing the interpolation, adding the rest of the longer variable name onto the value.

Example: user adds `$node` and `$nodeId` variables, both referencing `nodeFilter()`, maybe `$node` actually references `nodeFilter(labelFormat=id:label,valueFormat=id)`.

User uses `$nodeId` in a Performance Attribute query for the Node. They then try to set the Resource part of the query but it fails. Say `$node` and `$nodeId` were both set to a node Id of `1`. Interpolation finds `$node`, does a substitution on the string `$nodeId` and results in `1Id`. This is sent to the query to get resources and fails (`node[1Id]` is not found).

Solution is to add a word boundary to the regex before doing a replacement, e.g. do a regex match on `\$node\b` will fail on a string `$nodeId`; `\$nodeId\b` will correctly match.

# External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/OPG-488 
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
