### PR TITLE
OPG-483: Fix initialization of resource variable in PerformanceAttribute

### DIFF
--- a/src/datasources/perf-ds/PerformanceAttribute.tsx
+++ b/src/datasources/perf-ds/PerformanceAttribute.tsx
@@ -3,7 +3,7 @@ import { SelectableValue } from '@grafana/data'
 import { Segment, SegmentAsync, SegmentInput } from '@grafana/ui'
 import { SegmentSectionWithIcon } from 'components/SegmentSectionWithIcon'
 import { ValueOverrideSwitch } from 'components/ValueOverrideSwitch'
-import { getTemplateVariables } from 'lib/variableHelpers'
+import { getTemplateVariables, isTemplateVariable } from 'lib/variableHelpers'
 import { OnmsResourceDto } from '../../lib/api_types'
 import { PerformanceAttributeItemState, PerformanceAttributeState } from './types'
 
@@ -109,7 +109,19 @@ export const PerformanceAttribute: React.FC<PerformanceAttributesProps> = ({
 
       const resourceOptions: OnmsResourceDto[] = await loadResourcesByNode(node.id || node.label)
       const existingLabel = performanceState?.resource?.label
-      const resource = (existingLabel && resourceOptions && resourceOptions.filter(r => r.label === existingLabel)?.[0]) || {}
+
+      let resource = performanceState?.resource ?? {}
+
+      if (!isTemplateVariable(resource)) {
+          const resourceOption = (existingLabel && resourceOptions && resourceOptions.filter(r => r.label === existingLabel)?.[0]) || null
+
+          if (resourceOption?.id && resourceOption?.label) {
+            resource = {
+              id: resourceOption.id ?? '',
+              label: resourceOption.label ?? ''
+            }
+          }
+      }
 
       const state = {
         ...performanceState,


### PR DESCRIPTION
Fix the initialization of resource template variable in Performance Attribute queries.

If user had entered a template variable in the Resource input, it was being saved, but then upon returning to the edit screen it was being reset to empty, having the effect of not retaining its value.

This fix does a check if a template variable was used and doesn't reset the value.

# External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/OPG-483
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
