### PR TITLE
OPG-493: Fix mapping of subAttribute and datasource in Perf DS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,8 @@ commands:
             sudo apt-get update
             sudo apt-get -y --no-install-recommends install python3-pip
             pip3 install check-jsonschema
-            check-jsonschema --schemafile /tmp/plugin.schema.json src/plugin.json
+            # the plugin.schema.json uses 'python' regex format, including backslashes before '-' and '%'
+            check-jsonschema --regex-variant python --schemafile /tmp/plugin.schema.json src/plugin.json
   build-and-sign:
     steps:
       - run:

--- a/src/datasources/perf-ds/queries/queryBuilder.ts
+++ b/src/datasources/perf-ds/queries/queryBuilder.ts
@@ -111,12 +111,14 @@ export const buildAttributeQuerySource = (target: PerformanceQuery) => {
 
     const resourceId = target.attribute.resource.id || target.attribute.resource.label || ''
     const attribute = target.attribute.attribute.name || target.attribute.attribute.label || ''
+    const datasource = target.attribute.subAttribute !== undefined ? String(target.attribute.subAttribute) : ''
 
     const source = {
         label: target.attribute.label || target.attribute.attribute.name || target.attribute.attribute.label,
         nodeId: nodeId,
         resourceId: resourceId.replace('node[', 'nodeSource['),
         attribute: attribute,
+        datasource: datasource !== '' ? datasource : undefined,
         ['fallback-attribute']: target.attribute.fallbackAttribute?.name || undefined,
         aggregation: target.attribute.aggregation?.label?.toUpperCase() || undefined,
         transient: target.hide === true

--- a/src/datasources/perf-ds/types.ts
+++ b/src/datasources/perf-ds/types.ts
@@ -83,8 +83,9 @@ export interface OnmsMeasurementsQuerySource {
   label: string;
   resourceId: string;
   attribute: string;
-  ['fallback-attribute']: string;
-  aggregation: string;  // should be 'AVERAGE', 'MIN', 'MAX' or 'LAST'
+  datasource?: string;   // mapped from subAttribute
+  ['fallback-attribute']?: string;
+  aggregation?: string;  // should be 'AVERAGE', 'MIN', 'MAX' or 'LAST'
   transient: boolean;
   nodeId?: string; // this may be added or removed dynamically
 }

--- a/src/lib/dashboard-convert/performanceDs.ts
+++ b/src/lib/dashboard-convert/performanceDs.ts
@@ -57,7 +57,7 @@ const convertAttributeQuery = (source: any): PerformanceQuery | any => {
         name: source.attribute || '',
         label: source.attribute || ''
       },
-      subAttribute: source.subAttribute || undefined,
+      subAttribute: source.subattribute || undefined,
       fallbackAttribute: {},
       aggregation: {
         label: source.aggregation || ''


### PR DESCRIPTION
[NMS-16582](https://opennms.atlassian.net/browse/NMS-16582) may be caused by the fact that `subAttribute` and `datsource` are not correctly mapped in OPG v9 for Performance queries.

This fixes the mapping from the OPG query builder UI (`Sub-Attribute`) and also changes the name from `subAttribute` to `datasource` for the query to OpenNMS Measurements Rest API. It also fixes the dashboard converter to map it correctly.

Additionally, we use a Python script `check_jsonschema` to validate our `src/plugins.json` file during the Circle CI build process. The schema file we use has some Python-regex specific formulations like `\\-` and `\\%`. Needed to add `--regex-variant python` to account for this; apparently the default is not to use those Python-specific regex elements.

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/OPG-493
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)


[NMS-16582]: https://opennms.atlassian.net/browse/NMS-16582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ